### PR TITLE
refactor: use endsAt instead of finished in scopes

### DIFF
--- a/db/migrations/20210408041152-remove-finished-from-suspensions.js
+++ b/db/migrations/20210408041152-remove-finished-from-suspensions.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface /* , Sequelize */) => {
+    await queryInterface.removeColumn('suspensions', 'finished')
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('suspensions', 'finished', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    })
+  }
+}

--- a/src/jobs/finish-suspension.js
+++ b/src/jobs/finish-suspension.js
@@ -16,7 +16,6 @@ class FinishSuspensionJob {
         suspension.userId,
         suspension.rankBack && suspension.rank > 0 ? suspension.rank : 1)
     }
-    suspension.update({ finished: true })
 
     const username = await this._userService.getUsername(suspension.userId)
     this._discordMessageJob.run(`Finished **${username}**'s suspension`)

--- a/src/models/payout.js
+++ b/src/models/payout.js
@@ -19,10 +19,7 @@ module.exports = (sequelize, DataTypes) => {
     return (await Payout.findAll({
       where: { groupId },
       attributes: [
-        [
-          sequelize.fn('MAX', sequelize.col('until')),
-          'until'
-        ]
+        [sequelize.fn('MAX', sequelize.col('until')), 'until']
       ]
     }))[0]
   }

--- a/src/models/suspension.js
+++ b/src/models/suspension.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { Op } = require('sequelize')
-
 module.exports = (sequelize, DataTypes) => {
   const Suspension = sequelize.define('Suspension', {
     authorId: {
@@ -77,10 +75,7 @@ module.exports = (sequelize, DataTypes) => {
           [endsAtLiteral, 'endsAt']
         ]
       },
-      where: {
-        '$SuspensionCancellation.id$': null,
-        endsAt: { [Op.gt]: sequelize.literal('NOW()') }
-      },
+      where: { '$SuspensionCancellation.id$': null },
       include: [{
         model: models.SuspensionCancellation,
         attributes: []
@@ -88,7 +83,8 @@ module.exports = (sequelize, DataTypes) => {
         model: models.SuspensionExtension,
         as: 'extensions'
       }],
-      group: ['Suspension.id', 'extensions.id']
+      group: ['Suspension.id', 'extensions.id'],
+      having: sequelize.literal(`${endsAtLiteral.val} > NOW()`)
     })
     Suspension.addScope('finished', {
       attributes: {
@@ -96,10 +92,7 @@ module.exports = (sequelize, DataTypes) => {
           [endsAtLiteral, 'endsAt']
         ]
       },
-      where: {
-        '$SuspensionCancellation.id$': null,
-        endsAt: { [Op.lte]: sequelize.literal('NOW()') }
-      },
+      where: { '$SuspensionCancellation.id$': null },
       include: [{
         model: models.SuspensionCancellation,
         attributes: []
@@ -107,7 +100,8 @@ module.exports = (sequelize, DataTypes) => {
         model: models.SuspensionExtension,
         as: 'extensions'
       }],
-      group: ['Suspension.id', 'extensions.id']
+      group: ['Suspension.id', 'extensions.id'],
+      having: sequelize.literal(`${endsAtLiteral.val} <= NOW()`)
     })
   }
 

--- a/src/models/suspension.js
+++ b/src/models/suspension.js
@@ -68,8 +68,7 @@ module.exports = (sequelize, DataTypes) => {
       '("Suspension".duration||\' milliseconds\')::INTERVAL + ' +
       '(COALESCE(SUM(extensions.duration), 0)||\' milliseconds\')::INTERVAL'
     )
-
-    Suspension.addScope('defaultScope', {
+    const baseScope = {
       attributes: {
         include: [
           [endsAtLiteral, 'endsAt']
@@ -83,24 +82,15 @@ module.exports = (sequelize, DataTypes) => {
         model: models.SuspensionExtension,
         as: 'extensions'
       }],
-      group: ['Suspension.id', 'extensions.id'],
+      group: ['Suspension.id', 'extensions.id']
+    }
+
+    Suspension.addScope('defaultScope', {
+      ...baseScope,
       having: sequelize.literal(`${endsAtLiteral.val} > NOW()`)
     })
     Suspension.addScope('finished', {
-      attributes: {
-        include: [
-          [endsAtLiteral, 'endsAt']
-        ]
-      },
-      where: { '$SuspensionCancellation.id$': null },
-      include: [{
-        model: models.SuspensionCancellation,
-        attributes: []
-      }, {
-        model: models.SuspensionExtension,
-        as: 'extensions'
-      }],
-      group: ['Suspension.id', 'extensions.id'],
+      ...baseScope,
       having: sequelize.literal(`${endsAtLiteral.val} <= NOW()`)
     })
   }

--- a/src/models/suspension.js
+++ b/src/models/suspension.js
@@ -39,11 +39,6 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER,
       allowNull: false
     },
-    finished: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false
-    },
     groupId: {
       type: DataTypes.INTEGER,
       allowNull: false,


### PR DESCRIPTION
This PR removes the `finished` column from the suspensions table and makes the scopes use the new endsAt expression.