### PR TITLE
feat: use transactions in database migrations

### DIFF
--- a/db/migrations/20200410195126-create-training.js
+++ b/db/migrations/20200410195126-create-training.js
@@ -28,6 +28,7 @@ module.exports = {
       }
     })
   },
+
   down: (queryInterface /* , Sequelize */) => {
     return queryInterface.dropTable('trainings')
   }

--- a/db/migrations/20200410195638-create-suspension.js
+++ b/db/migrations/20200410195638-create-suspension.js
@@ -50,6 +50,7 @@ module.exports = {
       }
     })
   },
+
   down: (queryInterface /* , Sequelize */) => {
     return queryInterface.dropTable('suspensions')
   }

--- a/db/migrations/20200410195902-create-training-cancellation.js
+++ b/db/migrations/20200410195902-create-training-cancellation.js
@@ -32,6 +32,7 @@ module.exports = {
       }
     })
   },
+
   down: (queryInterface /* , Sequelize */) => {
     return queryInterface.dropTable('training_cancellations')
   }

--- a/db/migrations/20200410200215-create-suspension-cancellation.js
+++ b/db/migrations/20200410200215-create-suspension-cancellation.js
@@ -32,6 +32,7 @@ module.exports = {
       }
     })
   },
+
   down: (queryInterface /* , Sequelize */) => {
     return queryInterface.dropTable('suspension_cancellations')
   }

--- a/db/migrations/20200410200447-create-suspension-extension.js
+++ b/db/migrations/20200410200447-create-suspension-extension.js
@@ -36,6 +36,7 @@ module.exports = {
       }
     })
   },
+
   down: (queryInterface /* , Sequelize */) => {
     return queryInterface.dropTable('suspension_extensions')
   }

--- a/db/migrations/20200410234336-create-ban.js
+++ b/db/migrations/20200410234336-create-ban.js
@@ -36,6 +36,7 @@ module.exports = {
       }
     })
   },
+
   down: (queryInterface /* , Sequelize */) => {
     return queryInterface.dropTable('bans')
   }

--- a/db/migrations/20200410234944-create-ban-cancellation.js
+++ b/db/migrations/20200410234944-create-ban-cancellation.js
@@ -32,6 +32,7 @@ module.exports = {
       }
     })
   },
+
   down: (queryInterface /* , Sequelize */) => {
     return queryInterface.dropTable('ban_cancellations')
   }

--- a/db/migrations/20200421012523-create-exile.js
+++ b/db/migrations/20200421012523-create-exile.js
@@ -15,6 +15,7 @@ module.exports = {
       }
     })
   },
+
   down: (queryInterface /* , Sequelize */) => {
     return queryInterface.dropTable('exiles')
   }

--- a/db/migrations/20200426034737-create-payout.js
+++ b/db/migrations/20200426034737-create-payout.js
@@ -15,6 +15,7 @@ module.exports = {
       }
     })
   },
+
   down: (queryInterface /* , Sequelize */) => {
     return queryInterface.dropTable('payouts')
   }

--- a/db/migrations/20201226032621-change-user-ids-to-bigint.js
+++ b/db/migrations/20201226032621-change-user-ids-to-bigint.js
@@ -2,52 +2,56 @@
 
 module.exports = {
   up: (queryInterface /* , Sequelize */) => {
-    return Promise.all([
-      changeColumnType(queryInterface, 'bans', 'author_id', 'BIGINT'),
-      changeColumnType(queryInterface, 'bans', 'user_id', 'BIGINT'),
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        changeColumnType(queryInterface, 'bans', 'author_id', 'BIGINT', t),
+        changeColumnType(queryInterface, 'bans', 'user_id', 'BIGINT', t),
 
-      changeColumnType(queryInterface, 'ban_cancellations', 'author_id', 'BIGINT'),
+        changeColumnType(queryInterface, 'ban_cancellations', 'author_id', 'BIGINT', t),
 
-      changeColumnType(queryInterface, 'exiles', 'user_id', 'BIGINT'),
+        changeColumnType(queryInterface, 'exiles', 'user_id', 'BIGINT', t),
 
-      changeColumnType(queryInterface, 'suspensions', 'author_id', 'BIGINT'),
-      changeColumnType(queryInterface, 'suspensions', 'user_id', 'BIGINT'),
+        changeColumnType(queryInterface, 'suspensions', 'author_id', 'BIGINT', t),
+        changeColumnType(queryInterface, 'suspensions', 'user_id', 'BIGINT', t),
 
-      changeColumnType(queryInterface, 'suspension_cancellations', 'author_id', 'BIGINT'),
+        changeColumnType(queryInterface, 'suspension_cancellations', 'author_id', 'BIGINT', t),
 
-      changeColumnType(queryInterface, 'suspension_extensions', 'author_id', 'BIGINT'),
+        changeColumnType(queryInterface, 'suspension_extensions', 'author_id', 'BIGINT', t),
 
-      changeColumnType(queryInterface, 'trainings', 'author_id', 'BIGINT'),
+        changeColumnType(queryInterface, 'trainings', 'author_id', 'BIGINT', t),
 
-      changeColumnType(queryInterface, 'training_cancellations', 'author_id', 'BIGINT')
-    ])
+        changeColumnType(queryInterface, 'training_cancellations', 'author_id', 'BIGINT', t)
+      ])
+    })
   },
 
   down: (queryInterface /* , Sequelize */) => {
-    return Promise.all([
-      changeColumnType(queryInterface, 'training_cancellations', 'author_id', 'INTEGER'),
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        changeColumnType(queryInterface, 'training_cancellations', 'author_id', 'INTEGER', t),
 
-      changeColumnType(queryInterface, 'trainings', 'author_id', 'INTEGER'),
+        changeColumnType(queryInterface, 'trainings', 'author_id', 'INTEGER', t),
 
-      changeColumnType(queryInterface, 'suspension_extensions', 'author_id', 'INTEGER'),
+        changeColumnType(queryInterface, 'suspension_extensions', 'author_id', 'INTEGER', t),
 
-      changeColumnType(queryInterface, 'suspension_cancellations', 'author_id', 'INTEGER'),
+        changeColumnType(queryInterface, 'suspension_cancellations', 'author_id', 'INTEGER', t),
 
-      changeColumnType(queryInterface, 'suspensions', 'user_id', 'INTEGER'),
-      changeColumnType(queryInterface, 'suspensions', 'author_id', 'INTEGER'),
+        changeColumnType(queryInterface, 'suspensions', 'user_id', 'INTEGER', t),
+        changeColumnType(queryInterface, 'suspensions', 'author_id', 'INTEGER', t),
 
-      changeColumnType(queryInterface, 'exiles', 'user_id', 'INTEGER'),
+        changeColumnType(queryInterface, 'exiles', 'user_id', 'INTEGER', t),
 
-      changeColumnType(queryInterface, 'ban_cancellations', 'author_id', 'INTEGER'),
+        changeColumnType(queryInterface, 'ban_cancellations', 'author_id', 'INTEGER', t),
 
-      changeColumnType(queryInterface, 'bans', 'user_id', 'INTEGER'),
-      changeColumnType(queryInterface, 'bans', 'author_id', 'INTEGER')
-    ])
+        changeColumnType(queryInterface, 'bans', 'user_id', 'INTEGER', t),
+        changeColumnType(queryInterface, 'bans', 'author_id', 'INTEGER', t)
+      ])
+    })
   }
 }
 
-function changeColumnType (queryInterface, tableName, columnName, targetType) {
+function changeColumnType (queryInterface, tableName, columnName, targetType, transaction) {
   return queryInterface.changeColumn(tableName, columnName, {
     type: `${targetType} USING CAST("${columnName}" as ${targetType})`
-  })
+  }, { transaction })
 }

--- a/db/migrations/20201227023107-create-training-type.js
+++ b/db/migrations/20201227023107-create-training-type.js
@@ -1,111 +1,174 @@
 'use strict'
 
 module.exports = {
-  up: async (queryInterface, Sequelize) => {
-    await queryInterface.createTable('training_types', {
-      id: {
-        type: Sequelize.INTEGER,
-        autoIncrement: true,
-        primaryKey: true
-      },
-      name: {
-        type: Sequelize.STRING,
-        allowNull: false
-      },
-      abbreviation: {
-        type: Sequelize.STRING(8),
-        allowNull: false
-      }
-    })
-
-    const trainingTypes = (await queryInterface.sequelize.query('SELECT DISTINCT type FROM trainings'))
-      .shift()
-      .map(trainingType => {
-        const type = trainingType.type.toUpperCase()
-        return {
-          name: type,
-          abbreviation: type
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async t => {
+      await queryInterface.createTable('training_types', {
+        id: {
+          type: Sequelize.INTEGER,
+          autoIncrement: true,
+          primaryKey: true
+        },
+        name: {
+          type: Sequelize.STRING,
+          allowNull: false
+        },
+        abbreviation: {
+          type: Sequelize.STRING(8),
+          allowNull: false
         }
+      }, { transaction: t })
+
+      const trainingTypes = (await queryInterface.sequelize.query('SELECT DISTINCT type FROM trainings'))
+        .shift()
+        .map(trainingType => {
+          const type = trainingType.type.toUpperCase()
+          return { abbreviation: type, name: type }
+        })
+      if (trainingTypes.length > 0) {
+        await queryInterface.bulkInsert('training_types', trainingTypes, { transaction: t })
+      }
+
+      const cdTrainingTypeId = await queryInterface.rawSelect(
+        'training_types',
+        { where: { abbreviation: 'CD' }, transaction: t },
+        ['id']
+      )
+      const csrTrainingTypeId = await queryInterface.rawSelect(
+        'training_types',
+        { where: { abbreviation: 'CSR' }, transaction: t },
+        ['id']
+      )
+
+      await queryInterface.changeColumn(
+        'trainings',
+        'type',
+        {
+          type: 'VARCHAR(255) USING CAST ( "type" as VARCHAR(255) )',
+          allowNull: false
+        },
+        { transaction: t }
+      )
+      await queryInterface.dropEnum('enum_trainings_type', { transaction: t })
+
+      if (cdTrainingTypeId) {
+        await queryInterface.bulkUpdate(
+          'trainings',
+          { type: cdTrainingTypeId.toString() },
+          { type: 'cd' },
+          { transaction: t }
+        )
+      }
+      if (csrTrainingTypeId) {
+        await queryInterface.bulkUpdate(
+          'trainings',
+          { type: csrTrainingTypeId.toString() },
+          { type: 'csr' },
+          { transaction: t }
+        )
+      }
+
+      await queryInterface.changeColumn(
+        'trainings',
+        'type',
+        {
+          type: 'INTEGER USING CAST ( "type" as INTEGER )',
+          allowNull: false
+        },
+        { transaction: t }
+      )
+      await queryInterface.addConstraint('trainings', {
+        fields: ['type'],
+        type: 'foreign key',
+        name: 'trainings_type_id_training_types_fk',
+        references: {
+          table: 'training_types',
+          field: 'id'
+        },
+        onDelete: 'CASCADE',
+        transaction: t
       })
-    if (trainingTypes.length > 0) {
-      await queryInterface.bulkInsert('training_types', trainingTypes)
-    }
-
-    const cdTrainingTypeId = await queryInterface.rawSelect(
-      'training_types',
-      { where: { abbreviation: 'CD' } },
-      ['id']
-    )
-    const csrTrainingTypeId = await queryInterface.rawSelect(
-      'training_types',
-      { where: { abbreviation: 'CSR' } },
-      ['id']
-    )
-
-    await queryInterface.changeColumn('trainings', 'type', {
-      type: 'VARCHAR(255) USING CAST ( "type" as VARCHAR(255) )',
-      allowNull: false
+      return queryInterface.renameColumn(
+        'trainings',
+        'type',
+        'type_id',
+        { transaction: t }
+      )
     })
-    await queryInterface.dropEnum('enum_trainings_type')
-
-    if (cdTrainingTypeId) {
-      await queryInterface.bulkUpdate('trainings', { type: cdTrainingTypeId.toString() }, { type: 'cd' })
-    }
-    if (csrTrainingTypeId) {
-      await queryInterface.bulkUpdate('trainings', { type: csrTrainingTypeId.toString() }, { type: 'csr' })
-    }
-
-    await queryInterface.changeColumn('trainings', 'type', {
-      type: 'INTEGER USING CAST ( "type" as INTEGER )',
-      allowNull: false
-    })
-    await queryInterface.addConstraint('trainings', {
-      fields: ['type'],
-      type: 'foreign key',
-      name: 'trainings_type_id_training_types_fk',
-      references: {
-        table: 'training_types',
-        field: 'id'
-      },
-      onDelete: 'CASCADE'
-    })
-    return queryInterface.renameColumn('trainings', 'type', 'type_id')
   },
 
-  down: async (queryInterface, Sequelize) => {
-    await queryInterface.bulkDelete('training_types', { abbreviation: { [Sequelize.Op.notIn]: ['CD', 'CSR'] } })
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async t => {
+      await queryInterface.bulkDelete(
+        'training_types',
+        { abbreviation: { [Sequelize.Op.notIn]: ['CD', 'CSR'] } },
+        { transaction: t }
+      )
 
-    await queryInterface.renameColumn('trainings', 'type_id', 'type')
-    await queryInterface.removeConstraint('trainings', 'trainings_type_id_training_types_fk')
-    await queryInterface.changeColumn('trainings', 'type', {
-      type: 'VARCHAR(255) USING CAST ( "type" as VARCHAR(255) )',
-      allowNull: false
-    })
+      await queryInterface.renameColumn(
+        'trainings',
+        'type_id',
+        'type',
+        { transaction: t }
+      )
+      await queryInterface.removeConstraint(
+        'trainings',
+        'trainings_type_id_training_types_fk',
+        { transaction: t }
+      )
+      await queryInterface.changeColumn(
+        'trainings',
+        'type',
+        {
+          type: 'VARCHAR(255) USING CAST ( "type" as VARCHAR(255) )',
+          allowNull: false
+        },
+        { transaction: t }
+      )
 
-    const cdTrainingTypeId = await queryInterface.rawSelect(
-      'training_types',
-      { where: { abbreviation: 'CD' } },
-      ['id']
-    )
-    const csrTrainingTypeId = await queryInterface.rawSelect(
-      'training_types',
-      { where: { abbreviation: 'CSR' } },
-      ['id']
-    )
+      const cdTrainingTypeId = await queryInterface.rawSelect(
+        'training_types',
+        { where: { abbreviation: 'CD' }, transaction: t },
+        ['id']
+      )
+      const csrTrainingTypeId = await queryInterface.rawSelect(
+        'training_types',
+        { where: { abbreviation: 'CSR' }, transaction: t },
+        ['id']
+      )
 
-    await queryInterface.dropTable('training_types')
+      await queryInterface.dropTable('training_types', { transaction: t })
 
-    if (cdTrainingTypeId) {
-      await queryInterface.bulkUpdate('trainings', { type: 'cd' }, { type: cdTrainingTypeId.toString() })
-    }
-    if (csrTrainingTypeId) {
-      await queryInterface.bulkUpdate('trainings', { type: 'csr' }, { type: csrTrainingTypeId.toString() })
-    }
+      if (cdTrainingTypeId) {
+        await queryInterface.bulkUpdate(
+          'trainings',
+          { type: 'cd' },
+          { type: cdTrainingTypeId.toString() },
+          { transaction: t }
+        )
+      }
+      if (csrTrainingTypeId) {
+        await queryInterface.bulkUpdate(
+          'trainings',
+          { type: 'csr' },
+          { type: csrTrainingTypeId.toString() },
+          { transaction: t }
+        )
+      }
 
-    await queryInterface.sequelize.query('CREATE TYPE enum_trainings_type AS ENUM (\'cd\', \'csr\')')
-    return queryInterface.changeColumn('trainings', 'type', {
-      type: 'enum_trainings_type USING CAST ( "type" AS enum_trainings_type )',
-      allowNull: false
+      await queryInterface.sequelize.query(
+        'CREATE TYPE enum_trainings_type AS ENUM (\'cd\', \'csr\')',
+        { transaction: t }
+      )
+      return queryInterface.changeColumn(
+        'trainings',
+        'type',
+        {
+          type: 'enum_trainings_type USING CAST ( "type" AS enum_trainings_type )',
+          allowNull: false
+        },
+        { transaction: t }
+      )
     })
   }
 }

--- a/db/migrations/20210402235952-fix-constraints.js
+++ b/db/migrations/20210402235952-fix-constraints.js
@@ -1,62 +1,78 @@
 'use strict'
 
 module.exports = {
-  up: async (queryInterface, Sequelize) => {
-    await Promise.all([
-      updateForeignKey(queryInterface, 'ban_cancellations', 'ban_id', 'bans', 'CASCADE'),
-      updateForeignKey(queryInterface, 'suspension_cancellations', 'suspension_id', 'suspensions', 'CASCADE'),
-      updateForeignKey(queryInterface, 'suspension_extensions', 'suspension_id', 'suspensions', 'CASCADE'),
-      updateForeignKey(queryInterface, 'training_cancellations', 'training_id', 'trainings', 'CASCADE')
-    ])
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async t => {
+      await Promise.all([
+        updateForeignKey(queryInterface, 'ban_cancellations', 'ban_id', 'bans', 'CASCADE', t),
+        updateForeignKey(queryInterface, 'suspension_cancellations', 'suspension_id', 'suspensions', 'CASCADE', t),
+        updateForeignKey(queryInterface, 'suspension_extensions', 'suspension_id', 'suspensions', 'CASCADE', t),
+        updateForeignKey(queryInterface, 'training_cancellations', 'training_id', 'trainings', 'CASCADE', t)
+      ])
 
-    await queryInterface.changeColumn(
-      'trainings',
-      'type_id',
-      { type: Sequelize.INTEGER, allowNull: true }
-    )
-    await queryInterface.removeConstraint('trainings', 'trainings_type_id_training_types_fk')
-    await queryInterface.addConstraint('trainings', {
-      fields: ['type_id'],
-      type: 'foreign key',
-      name: 'trainings_type_id_fkey',
-      references: {
-        table: 'training_types',
-        field: 'id'
-      },
-      onDelete: 'SET NULL'
+      await queryInterface.changeColumn(
+        'trainings',
+        'type_id',
+        { type: Sequelize.INTEGER, allowNull: true },
+        { transaction: t }
+      )
+      await queryInterface.removeConstraint(
+        'trainings',
+        'trainings_type_id_training_types_fk',
+        { transaction: t }
+      )
+      return queryInterface.addConstraint('trainings', {
+        fields: ['type_id'],
+        type: 'foreign key',
+        name: 'trainings_type_id_fkey',
+        references: {
+          table: 'training_types',
+          field: 'id'
+        },
+        onDelete: 'SET NULL',
+        transaction: t
+      })
     })
   },
 
-  down: async (queryInterface, Sequelize) => {
-    await queryInterface.removeConstraint('trainings', 'trainings_type_id_fkey')
-    await queryInterface.addConstraint('trainings', {
-      fields: ['type_id'],
-      type: 'foreign key',
-      name: 'trainings_type_id_training_types_fk',
-      references: {
-        table: 'training_types',
-        field: 'id'
-      },
-      onDelete: 'CASCADE'
-    })
-    await queryInterface.bulkDelete('trainings', { type_id: null }) // will delete trainings with typeId = null
-    await queryInterface.changeColumn(
-      'trainings',
-      'type_id',
-      { type: Sequelize.INTEGER, allowNull: false }
-    )
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async t => {
+      await queryInterface.removeConstraint('trainings', 'trainings_type_id_fkey', { transaction: t })
+      await queryInterface.addConstraint('trainings', {
+        fields: ['type_id'],
+        type: 'foreign key',
+        name: 'trainings_type_id_training_types_fk',
+        references: {
+          table: 'training_types',
+          field: 'id'
+        },
+        onDelete: 'CASCADE',
+        transaction: t
+      })
+      await queryInterface.bulkDelete(
+        'trainings',
+        { type_id: null }, // will delete trainings with typeId = null
+        { transaction: t }
+      )
+      await queryInterface.changeColumn(
+        'trainings',
+        'type_id',
+        { type: Sequelize.INTEGER, allowNull: false },
+        { transaction: t }
+      )
 
-    await Promise.all([
-      updateForeignKey(queryInterface, 'training_cancellations', 'training_id', 'trainings'),
-      updateForeignKey(queryInterface, 'suspension_extensions', 'suspension_id', 'suspensions'),
-      updateForeignKey(queryInterface, 'suspension_cancellations', 'suspension_id', 'suspensions'),
-      updateForeignKey(queryInterface, 'ban_cancellations', 'ban_id', 'bans')
-    ])
+      return Promise.all([
+        updateForeignKey(queryInterface, 'training_cancellations', 'training_id', 'trainings', 'NO ACTION', t),
+        updateForeignKey(queryInterface, 'suspension_extensions', 'suspension_id', 'suspensions', 'NO ACTION', t),
+        updateForeignKey(queryInterface, 'suspension_cancellations', 'suspension_id', 'suspensions', 'NO ACTION', t),
+        updateForeignKey(queryInterface, 'ban_cancellations', 'ban_id', 'bans', 'NO ACTION', t)
+      ])
+    })
   }
 }
 
-async function updateForeignKey (queryInterface, tableName, columnName, targetTableName, onDeleteAction = 'NO ACTION') {
-  await queryInterface.removeConstraint(tableName, `${tableName}_${columnName}_fkey`)
+async function updateForeignKey (queryInterface, tableName, columnName, targetTableName, onDeleteAction, transaction) {
+  await queryInterface.removeConstraint(tableName, `${tableName}_${columnName}_fkey`, { transaction })
   return queryInterface.addConstraint(tableName, {
     fields: [columnName],
     type: 'foreign key',
@@ -65,6 +81,7 @@ async function updateForeignKey (queryInterface, tableName, columnName, targetTa
       table: targetTableName,
       field: 'id'
     },
-    onDelete: onDeleteAction
+    onDelete: onDeleteAction,
+    transaction
   })
 }

--- a/db/migrations/20210403023244-create-sequelize-meta.js
+++ b/db/migrations/20210403023244-create-sequelize-meta.js
@@ -1,20 +1,22 @@
 'use strict'
 
 module.exports = {
-  up: async (queryInterface /* , Sequelize */) => {
-    try {
-      const attributes = await queryInterface.describeTable('SequelizeMeta')
-      const rows = (await queryInterface.sequelize.query('SELECT name FROM "SequelizeMeta"'))
-        .shift()
-        .concat([{ name: '20210403023244-create-sequelize-meta.js' }])
+  up: (queryInterface /* , Sequelize */) => {
+    return queryInterface.sequelize.transaction(async t => {
+      try {
+        const attributes = await queryInterface.describeTable('SequelizeMeta')
+        const rows = (await queryInterface.sequelize.query('SELECT name FROM "SequelizeMeta"'))
+          .shift()
+          .concat([{ name: '20210403023244-create-sequelize-meta.js' }])
 
-      await queryInterface.createTable('sequelize_meta', attributes)
-      await queryInterface.bulkInsert('sequelize_meta', rows)
-    } catch (err) {
-      if (!err.message.includes('No description found for "SequelizeMeta" table.')) {
-        throw err
+        await queryInterface.createTable('sequelize_meta', attributes, { transaction: t })
+        return queryInterface.bulkInsert('sequelize_meta', rows, { transaction: t })
+      } catch (err) {
+        if (!err.message.includes('No description found for "SequelizeMeta" table.')) {
+          throw err
+        }
       }
-    }
+    })
   },
 
   down: async (/* queryInterface, Sequelize */) => {

--- a/db/migrations/20210403023244-create-sequelize-meta.js
+++ b/db/migrations/20210403023244-create-sequelize-meta.js
@@ -19,7 +19,8 @@ module.exports = {
     })
   },
 
-  down: async (/* queryInterface, Sequelize */) => {
+  down: (/* queryInterface, Sequelize */) => {
     // Do nothing, we want to keep the underscored table name.
+    return Promise.resolve()
   }
 }

--- a/db/migrations/20210403154022-delete-sequelize-meta.js
+++ b/db/migrations/20210403154022-delete-sequelize-meta.js
@@ -4,7 +4,7 @@ module.exports = {
   up: async (queryInterface /* , Sequelize */) => {
     try {
       await queryInterface.describeTable('SequelizeMeta')
-      await queryInterface.dropTable('SequelizeMeta')
+      return queryInterface.dropTable('SequelizeMeta')
     } catch (err) {
       if (!err.message.includes('No description found for "SequelizeMeta" table.')) {
         throw err

--- a/db/migrations/20210403154022-delete-sequelize-meta.js
+++ b/db/migrations/20210403154022-delete-sequelize-meta.js
@@ -12,7 +12,8 @@ module.exports = {
     }
   },
 
-  down: async (/* queryInterface, Sequelize */) => {
+  down: (/* queryInterface, Sequelize */) => {
     // Do nothing, we want to keep using the underscored table name.
+    return Promise.resolve()
   }
 }

--- a/db/migrations/20210404033158-add-group-id.js
+++ b/db/migrations/20210404033158-add-group-id.js
@@ -1,36 +1,40 @@
 'use strict'
 
 module.exports = {
-  up: async (queryInterface, Sequelize) => {
-    await Promise.all([
-      addGroupIdColumn(queryInterface, Sequelize, 'bans'),
-      addGroupIdColumn(queryInterface, Sequelize, 'exiles'),
-      addGroupIdColumn(queryInterface, Sequelize, 'payouts'),
-      addGroupIdColumn(queryInterface, Sequelize, 'suspensions'),
-      addGroupIdColumn(queryInterface, Sequelize, 'trainings'),
-      addGroupIdColumn(queryInterface, Sequelize, 'training_types')
-    ])
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        addGroupIdColumn(queryInterface, Sequelize, 'bans', t),
+        addGroupIdColumn(queryInterface, Sequelize, 'exiles', t),
+        addGroupIdColumn(queryInterface, Sequelize, 'payouts', t),
+        addGroupIdColumn(queryInterface, Sequelize, 'suspensions', t),
+        addGroupIdColumn(queryInterface, Sequelize, 'trainings', t),
+        addGroupIdColumn(queryInterface, Sequelize, 'training_types', t)
+      ])
+    })
   },
 
-  down: async (queryInterface /* , Sequelize */) => {
-    await Promise.all([
-      queryInterface.removeColumn('bans', 'group_id'),
-      queryInterface.removeColumn('exiles', 'group_id'),
-      queryInterface.removeColumn('payouts', 'group_id'),
-      queryInterface.removeColumn('suspensions', 'group_id'),
-      queryInterface.removeColumn('trainings', 'group_id'),
-      queryInterface.removeColumn('training_types', 'group_id')
-    ])
+  down: (queryInterface /* , Sequelize */) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.removeColumn('bans', 'group_id', { transaction: t }),
+        queryInterface.removeColumn('exiles', 'group_id', { transaction: t }),
+        queryInterface.removeColumn('payouts', 'group_id', { transaction: t }),
+        queryInterface.removeColumn('suspensions', 'group_id', { transaction: t }),
+        queryInterface.removeColumn('trainings', 'group_id', { transaction: t }),
+        queryInterface.removeColumn('training_types', 'group_id', { transaction: t })
+      ])
+    })
   }
 }
 
-async function addGroupIdColumn (queryInterface, Sequelize, tableName) {
+async function addGroupIdColumn (queryInterface, Sequelize, tableName, transaction) {
   await queryInterface.addColumn(tableName, 'group_id', {
     type: Sequelize.INTEGER
-  })
-  await queryInterface.sequelize.query(`UPDATE ${tableName} SET group_id=1018818`)
+  }, { transaction })
+  await queryInterface.sequelize.query(`UPDATE ${tableName} SET group_id=1018818`, { transaction })
   return queryInterface.changeColumn(tableName, 'group_id', {
     type: Sequelize.INTEGER,
     allowNull: false
-  })
+  }, { transaction })
 }

--- a/db/migrations/20210408041152-remove-finished-from-suspensions.js
+++ b/db/migrations/20210408041152-remove-finished-from-suspensions.js
@@ -1,12 +1,12 @@
 'use strict'
 
 module.exports = {
-  up: async (queryInterface /* , Sequelize */) => {
-    await queryInterface.removeColumn('suspensions', 'finished')
+  up: (queryInterface /* , Sequelize */) => {
+    return queryInterface.removeColumn('suspensions', 'finished')
   },
 
-  down: async (queryInterface, Sequelize) => {
-    await queryInterface.addColumn('suspensions', 'finished', {
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('suspensions', 'finished', {
       type: Sequelize.BOOLEAN,
       allowNull: false,
       defaultValue: false


### PR DESCRIPTION
Transactions are now used in the database migrations to allow for atomic migrations.