### PR TITLE
feat: migrate ranks to role IDs

### DIFF
--- a/config/container.yml
+++ b/config/container.yml
@@ -16,7 +16,7 @@ services:
   UserController:
     class: src/controllers/v1
     main: UserController
-    arguments: ['@UserService']
+    arguments: ['@GroupService', '@UserService']
 
   # Jobs
   AcceptJoinRequestsJob:
@@ -88,7 +88,7 @@ services:
   BanService:
     class: src/services
     main: BanService
-    arguments: ['@DiscordMessageJob', '@UserService']
+    arguments: ['@DiscordMessageJob', '@GroupService', '@UserService']
   CatalogService:
     class: src/services
     main: CatalogService

--- a/db/migrations/20210409103041-change-rank-to-role-id.js
+++ b/db/migrations/20210409103041-change-rank-to-role-id.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const ranksToRoleIds = {
+  0: 6508456,
+  1: 6508585,
+  2: 6694400,
+  3: 7024392,
+  4: 6508455,
+  5: 6766826
+}
+
+module.exports = {
+  up: (queryInterface /* , Sequelize */) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        changeColumn(queryInterface, 'bans', true, t),
+        changeColumn(queryInterface, 'suspensions', true, t),
+        queryInterface.renameColumn(
+          'suspensions',
+          'rank_back',
+          'role_back',
+          { transaction: t }
+        )
+      ])
+    })
+  },
+
+  down: (queryInterface /* , Sequelize */) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        changeColumn(queryInterface, 'bans', false, t),
+        changeColumn(queryInterface, 'suspensions', false, t),
+        queryInterface.renameColumn(
+          'suspensions',
+          'role_back',
+          'rank_back',
+          { transaction: t }
+        )
+      ])
+    })
+  }
+}
+
+async function changeColumn (queryInterface, tableName, up, transaction) {
+  const promises = []
+  for (let [rank, roleId] of Object.entries(ranksToRoleIds)) {
+    rank = parseInt(rank)
+    promises.push(queryInterface.bulkUpdate(
+      tableName,
+      up ? { rank: roleId } : { role_id: rank },
+      up ? { rank } : { role_id: roleId },
+      { transaction }
+    ))
+  }
+  await Promise.all(promises)
+  return queryInterface.renameColumn(
+    tableName,
+    up ? 'rank' : 'role_id',
+    up ? 'role_id' : 'rank',
+    { transaction }
+  )
+}

--- a/src/controllers/v1/group.js
+++ b/src/controllers/v1/group.js
@@ -312,7 +312,7 @@ class GroupController {
           body('authorId').exists().isInt().toInt(),
           body('reason').exists().isString(),
           body('duration').exists().isInt().toInt(),
-          body('rankBack').exists().isBoolean().toBoolean()
+          body('roleBack').exists().isBoolean().toBoolean()
         ]
       case 'cancelSuspension':
         return [
@@ -340,7 +340,7 @@ class GroupController {
           body('editorId').exists().isInt().toInt(),
           body('changes.authorId').optional().isInt().toInt(),
           body('changes.reason').optional().isString(),
-          body('changes.rankBack').optional().isBoolean().toBoolean()
+          body('changes.roleBack').optional().isBoolean().toBoolean()
         ]
 
         // TrainingService

--- a/src/controllers/v1/group.js
+++ b/src/controllers/v1/group.js
@@ -37,8 +37,11 @@ class GroupController {
     res.json(await this._groupService.demoteMember(req.params.groupId, req.params.userId, req.body.authorId))
   }
 
-  async changeMemberRank (req, res) {
-    res.json(await this._groupService.changeMemberRank(req.params.groupId, req.params.userId, req.body))
+  async changeMemberRole (req, res) {
+    res.json(await this._groupService.changeMemberRole(req.params.groupId, req.params.userId, {
+      role: req.body.rank,
+      authorId: req.body.authorId
+    }))
   }
 
   // BanService
@@ -206,7 +209,7 @@ class GroupController {
           body('authorId').optional().isInt().toInt()
         ]
 
-      case 'changeMemberRank':
+      case 'changeMemberRole':
         return [
           header('authorization').exists().isString(),
           param('groupId').isInt().toInt(),

--- a/src/controllers/v1/user.js
+++ b/src/controllers/v1/user.js
@@ -3,7 +3,8 @@
 const { param, header, body } = require('express-validator')
 
 class UserController {
-  constructor (userService) {
+  constructor (groupService, userService) {
+    this._groupService = groupService
     this._userService = userService
   }
 
@@ -20,11 +21,11 @@ class UserController {
   }
 
   async getRank (req, res) {
-    res.json(await this._userService.getRank(req.params.userId, req.params.groupId))
+    res.json(await this._groupService.getRank(req.params.groupId, req.params.userId))
   }
 
   async getRole (req, res) {
-    res.json(await this._userService.getRole(req.params.userId, req.params.groupId))
+    res.json(await this._groupService.getRole(req.params.groupId, req.params.userId))
   }
 
   async getUser (req, res) {

--- a/src/jobs/accept-join-requests.js
+++ b/src/jobs/accept-join-requests.js
@@ -28,7 +28,7 @@ class AcceptJoinRequestsJob {
           this._discordMessageJob.run(`Accepted **${request.requester.username}**'s join request`)
 
           if (await Suspension.findOne({ where: { groupId, userId } })) {
-            await this._groupService.setMemberRank(groupId, userId, 2)
+            await this._groupService.setMemberRole(groupId, userId, 2)
             this._discordMessageJob.run(`Promoted **${request.requester.username}** from **Customer** to **Suspended**`)
           }
         }

--- a/src/jobs/finish-suspension.js
+++ b/src/jobs/finish-suspension.js
@@ -15,7 +15,7 @@ class FinishSuspensionJob {
         await this._groupService.setMemberRole(
           suspension.groupId,
           suspension.userId,
-          suspension.roleBack ? suspension.roleId : 1)
+          suspension.roleBack ? { id: suspension.roleId } : 1)
       } catch {
         await this._groupService.setMemberRole(suspension.groupId, suspension.userId, 1)
       }

--- a/src/jobs/finish-suspension.js
+++ b/src/jobs/finish-suspension.js
@@ -8,13 +8,17 @@ class FinishSuspensionJob {
   }
 
   async run (suspension) {
-    const rank = await this._userService.getRank(suspension.userId, suspension.groupId)
+    const role = await this._userService.getRole(suspension.userId, suspension.groupId)
 
-    if (rank !== 0) {
-      await this._groupService.setMemberRole(
-        suspension.groupId,
-        suspension.userId,
-        suspension.rankBack && suspension.rank > 0 ? suspension.rank : 1)
+    if (role.rank !== 0) {
+      try {
+        await this._groupService.setMemberRole(
+          suspension.groupId,
+          suspension.userId,
+          suspension.roleBack ? suspension.roleId : 1)
+      } catch {
+        await this._groupService.setMemberRole(suspension.groupId, suspension.userId, 1)
+      }
     }
 
     const username = await this._userService.getUsername(suspension.userId)

--- a/src/jobs/finish-suspension.js
+++ b/src/jobs/finish-suspension.js
@@ -16,7 +16,10 @@ class FinishSuspensionJob {
           suspension.groupId,
           suspension.userId,
           suspension.roleBack ? { id: suspension.roleId } : 1)
-      } catch {
+      } catch (err) {
+        if (!suspension.roleBack) {
+          throw err
+        }
         await this._groupService.setMemberRole(suspension.groupId, suspension.userId, 1)
       }
     }

--- a/src/jobs/finish-suspension.js
+++ b/src/jobs/finish-suspension.js
@@ -8,7 +8,7 @@ class FinishSuspensionJob {
   }
 
   async run (suspension) {
-    const role = await this._userService.getRole(suspension.userId, suspension.groupId)
+    const role = await this._groupService.getRole(suspension.groupId, suspension.userId)
 
     if (role.rank !== 0) {
       try {

--- a/src/jobs/finish-suspension.js
+++ b/src/jobs/finish-suspension.js
@@ -11,7 +11,7 @@ class FinishSuspensionJob {
     const rank = await this._userService.getRank(suspension.userId, suspension.groupId)
 
     if (rank !== 0) {
-      await this._groupService.setMemberRank(
+      await this._groupService.setMemberRole(
         suspension.groupId,
         suspension.userId,
         suspension.rankBack && suspension.rank > 0 ? suspension.rank : 1)

--- a/src/models/ban.js
+++ b/src/models/ban.js
@@ -14,9 +14,10 @@ module.exports = (sequelize, DataTypes) => {
         notEmpty: true
       }
     },
-    rank: {
+    roleId: {
       type: DataTypes.INTEGER,
-      allowNull: false
+      allowNull: false,
+      field: 'role_id'
     },
     date: {
       type: DataTypes.DATE,

--- a/src/models/suspension.js
+++ b/src/models/suspension.js
@@ -28,14 +28,15 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER,
       allowNull: false
     },
-    rankBack: {
+    roleBack: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
-      field: 'rank_back'
+      field: 'role_back'
     },
-    rank: {
+    roleId: {
       type: DataTypes.INTEGER,
-      allowNull: false
+      allowNull: false,
+      field: 'role_id'
     },
     groupId: {
       type: DataTypes.INTEGER,

--- a/src/models/suspension.js
+++ b/src/models/suspension.js
@@ -83,7 +83,8 @@ module.exports = (sequelize, DataTypes) => {
         model: models.SuspensionExtension,
         as: 'extensions'
       }],
-      group: ['Suspension.id', 'extensions.id']
+      group: ['Suspension.id', 'extensions.id'],
+      subQuery: false
     }
 
     Suspension.addScope('defaultScope', {

--- a/src/routes/groups.js
+++ b/src/routes/groups.js
@@ -55,10 +55,10 @@ class GroupsRouter {
 
     router.put(
       '/:groupId/users/:userId',
-      groupController.validate('changeMemberRank'),
+      groupController.validate('changeMemberRole'),
       handleValidationResult,
       authenticate,
-      groupController.changeMemberRank.bind(groupController)
+      groupController.changeMemberRole.bind(groupController)
     )
 
     // BanService

--- a/src/services/ban.js
+++ b/src/services/ban.js
@@ -7,8 +7,9 @@ const { Ban, BanCancellation } = require('../models')
 const applicationConfig = require('../../config/application')
 
 class BanService {
-  constructor (discordMessageJob, userService) {
+  constructor (discordMessageJob, groupService, userService) {
     this._discordMessageJob = discordMessageJob
+    this._groupService = groupService
     this._userService = userService
   }
 
@@ -28,7 +29,7 @@ class BanService {
     if (await Ban.findOne({ where: { groupId, userId } })) {
       throw new ConflictError('User is already banned.')
     }
-    const role = await this._userService.getRole(userId, groupId)
+    const role = await this._groupService.getRole(groupId, groupId)
     if (applicationConfig.unbannableRanks.some(range => inRange(role.rank, range))) {
       throw new ForbiddenError('User\'s role is unbannable.')
     }

--- a/src/services/ban.js
+++ b/src/services/ban.js
@@ -28,17 +28,17 @@ class BanService {
     if (await Ban.findOne({ where: { groupId, userId } })) {
       throw new ConflictError('User is already banned.')
     }
-    const rank = await this._userService.getRank(userId, groupId)
-    if (applicationConfig.unbannableRanks.some(range => inRange(rank, range))) {
-      throw new ForbiddenError('User\'s rank is unbannable.')
+    const role = await this._userService.getRole(userId, groupId)
+    if (applicationConfig.unbannableRanks.some(range => inRange(role.rank, range))) {
+      throw new ForbiddenError('User\'s role is unbannable.')
     }
 
     const ban = await Ban.create({
-      groupId,
-      authorId,
       userId,
-      rank,
-      reason
+      authorId,
+      groupId,
+      reason,
+      roleId: role.id
     })
 
     const [username, authorName] = await Promise.all([

--- a/src/services/exile.js
+++ b/src/services/exile.js
@@ -29,7 +29,7 @@ class ExileService {
     if (await Exile.findOne({ where: { groupId, userId } })) {
       throw new ConflictError('User is already exiled.')
     }
-    const rank = await this._userService.getRank(userId, groupId)
+    const rank = await this._groupService.getRank(groupId, userId)
     if (applicationConfig.unexilableRanks.some(range => inRange(rank, range))) {
       throw new ForbiddenError('Cannot exile members on this rank.')
     }

--- a/src/services/group.js
+++ b/src/services/group.js
@@ -62,14 +62,12 @@ class GroupService {
   }
 
   async changeMemberRole (groupId, userId, { role, authorId }) {
-    const oldRank = await this._userService.getRank(userId, groupId)
-    if ([0, 255].includes(oldRank)) {
-      throw new ForbiddenError('Cannot promote members on this rank.')
+    const oldRole = await this._userService.getRole(userId, groupId)
+    if ([0, 255].includes(oldRole.rank)) {
+      throw new ForbiddenError('Cannot promote members on this role.')
     }
 
     const newRole = await this.setMemberRole(groupId, userId, role)
-    const roles = await this.getRoles(groupId)
-    const oldRole = roles.roles.find(role => role.rank === oldRank)
     const username = await this._userService.getUsername(userId)
     if (oldRole.id !== newRole.id) {
       if (typeof authorId !== 'undefined') {

--- a/src/services/group.js
+++ b/src/services/group.js
@@ -44,40 +44,39 @@ class GroupService {
     return shout
   }
 
-  async setMemberRank (groupId, userId, rank) {
-    let role = rank
+  async setMemberRole (groupId, userId, role) {
     if (typeof role === 'number') {
       const roles = await this.getRoles(groupId)
       role = roles.roles.find(otherRole => otherRole.rank === role)
       if (!role) {
-        throw new NotFoundError('Rank not found.')
+        throw new NotFoundError('Role not found.')
       }
     }
     const client = this._robloxManager.getClient(groupId)
     const group = await client.getGroup(groupId)
     await group.updateMember(userId, role.id)
 
-    this._webSocketManager.broadcast('rankChange', { groupId, userId, rank: role.rank })
+    this._webSocketManager.broadcast('rankChange', { groupId, rank: role.rank, userId })
 
     return role
   }
 
-  async changeMemberRank (groupId, userId, { rank, authorId }) {
+  async changeMemberRole (groupId, userId, { role, authorId }) {
     const oldRank = await this._userService.getRank(userId, groupId)
     if ([0, 255].includes(oldRank)) {
       throw new ForbiddenError('Cannot promote members on this rank.')
     }
 
-    const newRole = await this.setMemberRank(groupId, userId, rank)
+    const newRole = await this.setMemberRole(groupId, userId, role)
     const roles = await this.getRoles(groupId)
     const oldRole = roles.roles.find(role => role.rank === oldRank)
     const username = await this._userService.getUsername(userId)
     if (oldRole.id !== newRole.id) {
       if (typeof authorId !== 'undefined') {
         const authorName = await this._userService.getUsername(authorId)
-        this._discordMessageJob.run(`**${authorName}** changed **${username}**'s rank from **${oldRole.name}** to **${newRole.name}**`)
+        this._discordMessageJob.run(`**${authorName}** changed **${username}**'s role from **${oldRole.name}** to **${newRole.name}**`)
       } else {
-        this._discordMessageJob.run(`Changed **${username}**'s rank from **${oldRole.name}** to **${newRole.name}**`)
+        this._discordMessageJob.run(`Changed **${username}**'s role from **${oldRole.name}** to **${newRole.name}**`)
       }
     }
 
@@ -87,7 +86,7 @@ class GroupService {
   async promoteMember (groupId, userId, authorId) {
     const rank = await this._userService.getRank(userId, groupId)
     if ([0, 255].includes(rank) || applicationConfig.unpromotableRanks.some(range => inRange(rank, range))) {
-      throw new ForbiddenError('Cannot promote members on this rank.')
+      throw new ForbiddenError('Cannot promote members on this role.')
     }
     const roles = await this.getRoles(groupId)
     const role = roles.roles
@@ -95,15 +94,15 @@ class GroupService {
       .slice(roles.roles.findIndex(role => role.rank === rank) + 1)
       .find(role => !applicationConfig.skippedRanks.some(range => inRange(role.rank, range)))
     if (!role || role.rank === 255) {
-      throw new ForbiddenError('Member is already the highest obtainable rank.')
+      throw new ForbiddenError('Member is already the highest obtainable role.')
     }
-    return this.changeMemberRank(groupId, userId, { rank: role, authorId })
+    return this.changeMemberRole(groupId, userId, { role, authorId })
   }
 
   async demoteMember (groupId, userId, authorId) {
     const rank = await this._userService.getRank(userId, groupId)
     if ([0, 255].includes(rank) || applicationConfig.undemotableRanks.some(range => inRange(rank, range))) {
-      throw new ForbiddenError('Cannot demote members on this rank.')
+      throw new ForbiddenError('Cannot demote members on this role.')
     }
     const roles = await this.getRoles(groupId)
     const role = roles.roles
@@ -111,9 +110,9 @@ class GroupService {
       .slice(roles.roles.findIndex(role => role.rank === rank) + 1)
       .find(role => !applicationConfig.skippedRanks.some(range => inRange(role.rank, range)))
     if (!role || role.rank === 0) {
-      throw new ForbiddenError('Member is already the lowest obtainable rank.')
+      throw new ForbiddenError('Member is already the lowest obtainable role.')
     }
-    return this.changeMemberRank(groupId, userId, { rank: role, authorId })
+    return this.changeMemberRole(groupId, userId, { role, authorId })
   }
 
   async kickMember (groupId, userId) {

--- a/src/services/suspension.js
+++ b/src/services/suspension.js
@@ -39,7 +39,7 @@ class SuspensionService {
     }
 
     if (rank > 0 && rank !== 2) {
-      await this._groupService.setMemberRank(groupId, userId, 2)
+      await this._groupService.setMemberRole(groupId, userId, 2)
     }
     const suspension = await Suspension.create({
       groupId,
@@ -72,7 +72,7 @@ class SuspensionService {
     const rank = await this._userService.getRank(suspension.userId, groupId)
 
     if (rank !== 0) {
-      await this._groupService.setMemberRank(groupId, suspension.userId, suspension.rank)
+      await this._groupService.setMemberRole(groupId, suspension.userId, suspension.rank)
     }
 
     const cancellation = await SuspensionCancellation.create({ suspensionId: suspension.id, authorId, reason })

--- a/src/services/suspension.js
+++ b/src/services/suspension.js
@@ -33,7 +33,7 @@ class SuspensionService {
     if (await Suspension.findOne({ where: { groupId, userId } })) {
       throw new ConflictError('User is already suspended.')
     }
-    const role = await this._userService.getRole(userId, groupId)
+    const role = await this._groupService.getRole(groupId, userId)
     if (applicationConfig.unbannableRanks.some(range => inRange(role.rank, range))) {
       throw new ForbiddenError('User\'s role is unsuspendable.')
     }
@@ -69,7 +69,7 @@ class SuspensionService {
 
   async unsuspend (groupId, userId, { authorId, reason }) {
     const suspension = await this.getSuspension(groupId, userId)
-    const role = await this._userService.getRole(suspension.userId, groupId)
+    const role = await this._groupService.getRole(groupId, suspension.userId)
 
     if (role.rank !== 0) {
       try {

--- a/src/services/suspension.js
+++ b/src/services/suspension.js
@@ -73,7 +73,7 @@ class SuspensionService {
 
     if (role.rank !== 0) {
       try {
-        await this._groupService.setMemberRole(groupId, suspension.userId, suspension.roleId)
+        await this._groupService.setMemberRole(groupId, suspension.userId, { id: suspension.roleId })
       } catch {
         await this._groupService.setMemberRole(groupId, suspension.userId, 1)
       }

--- a/src/services/suspension.js
+++ b/src/services/suspension.js
@@ -29,26 +29,26 @@ class SuspensionService {
     return suspension
   }
 
-  async suspend (groupId, userId, { rankBack, duration, authorId, reason }) {
+  async suspend (groupId, userId, { authorId, duration, reason, roleBack }) {
     if (await Suspension.findOne({ where: { groupId, userId } })) {
       throw new ConflictError('User is already suspended.')
     }
-    const rank = await this._userService.getRank(userId, groupId)
-    if (applicationConfig.unbannableRanks.some(range => inRange(rank, range))) {
-      throw new ForbiddenError('User\'s rank is unsuspendable.')
+    const role = await this._userService.getRole(userId, groupId)
+    if (applicationConfig.unbannableRanks.some(range => inRange(role.rank, range))) {
+      throw new ForbiddenError('User\'s role is unsuspendable.')
     }
 
-    if (rank > 0 && rank !== 2) {
+    if (role.rank > 0 && role.rank !== 2) {
       await this._groupService.setMemberRole(groupId, userId, 2)
     }
     const suspension = await Suspension.create({
-      groupId,
       authorId,
-      userId,
-      rank,
       duration,
-      rankBack,
-      reason
+      groupId,
+      reason,
+      roleBack,
+      roleId: role.id,
+      userId
     })
 
     cron.scheduleJob(
@@ -69,13 +69,17 @@ class SuspensionService {
 
   async unsuspend (groupId, userId, { authorId, reason }) {
     const suspension = await this.getSuspension(groupId, userId)
-    const rank = await this._userService.getRank(suspension.userId, groupId)
+    const role = await this._userService.getRole(suspension.userId, groupId)
 
-    if (rank !== 0) {
-      await this._groupService.setMemberRole(groupId, suspension.userId, suspension.rank)
+    if (role.rank !== 0) {
+      try {
+        await this._groupService.setMemberRole(groupId, suspension.userId, suspension.roleId)
+      } catch {
+        await this._groupService.setMemberRole(groupId, suspension.userId, 1)
+      }
     }
 
-    const cancellation = await SuspensionCancellation.create({ suspensionId: suspension.id, authorId, reason })
+    const cancellation = await SuspensionCancellation.create({ authorId, reason, suspensionId: suspension.id })
 
     const job = cron.scheduledJobs[`suspension_${suspension.id}`]
     if (job) {
@@ -151,8 +155,8 @@ class SuspensionService {
     if (typeof changes.reason !== 'undefined') {
       this._discordMessageJob.run(`**${editorName}** changed the reason of **${username}**'s suspension to *"${suspension.reason}"*`)
     }
-    if (typeof changes.rankBack !== 'undefined') {
-      this._discordMessageJob.run(`**${editorName}** changed the rankBack option of **${username}**'s suspension to **${suspension.rankBack ? 'yes' : 'no'}**`)
+    if (typeof changes.roleBack !== 'undefined') {
+      this._discordMessageJob.run(`**${editorName}** changed the roleBack option of **${username}**'s suspension to **${suspension.roleBack ? 'yes' : 'no'}**`)
     }
 
     return suspension

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -33,22 +33,6 @@ class UserService {
     return (await client.apis.usersAPI.getUsersByIds({ userIds })).data
   }
 
-  async getRank (userId, groupId) {
-    const client = this._robloxManager.getClient(groupId)
-    const user = await client.getUser(userId)
-    const groups = await user.getGroups()
-    const group = groups.data.find(group => group.group.id === groupId)
-    return group ? group.role.rank : 0
-  }
-
-  async getRole (userId, groupId) {
-    const client = this._robloxManager.getClient(groupId)
-    const user = await client.getUser(userId)
-    const groups = await user.getGroups()
-    const group = groups.data.find(group => group.group.id === groupId)
-    return group?.role ?? { name: 'Guest', rank: 0 }
-  }
-
   async getUsername (userId) {
     return (await this.getUser(userId)).name
   }

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -46,7 +46,7 @@ class UserService {
     const user = await client.getUser(userId)
     const groups = await user.getGroups()
     const group = groups.data.find(group => group.group.id === groupId)
-    return group ? group.role.name : 'Guest'
+    return group?.role ?? { name: 'Guest', rank: 0 }
   }
 
   async getUsername (userId) {

--- a/test/unit/models/ban.spec.js
+++ b/test/unit/models/ban.spec.js
@@ -18,7 +18,7 @@ describe('src/models/ban', () => {
   checkModelName(Ban)('Ban')
 
   context('properties', () => {
-    ['authorId', 'date', 'groupId', 'rank', 'reason', 'userId'].forEach(checkPropertyExists(ban))
+    ['authorId', 'date', 'groupId', 'reason', 'roleId', 'userId'].forEach(checkPropertyExists(ban))
   })
 
   context('associations', () => {

--- a/test/unit/models/suspension.spec.js
+++ b/test/unit/models/suspension.spec.js
@@ -20,7 +20,7 @@ describe('src/models/suspension', () => {
 
   context('properties', () => {
     [
-      'authorId', 'date', 'duration', 'groupId', 'rank', 'rankBack', 'reason', 'userId'
+      'authorId', 'date', 'duration', 'groupId', 'reason', 'roleBack', 'roleId', 'userId'
     ].forEach(checkPropertyExists(suspension))
   })
 


### PR DESCRIPTION
Ranks are migrated to their respective role IDs to avoid problems with several roles being able to have the same rank.

! These code changes change the result of the `/groups/:groupId/users/:userId/role` endpoint to the role object returned by Roblox.

This PR resolves #237 