### PR TITLE
fix: use correct trainingId in training query

### DIFF
--- a/src/services/training.js
+++ b/src/services/training.js
@@ -19,7 +19,7 @@ class TrainingService {
   }
 
   async getTraining (groupId, trainingId, scope) {
-    const training = await Training.scope(scope ?? 'defaultScope').findOne({ where: { groupId, trainingId } })
+    const training = await Training.scope(scope ?? 'defaultScope').findOne({ where: { groupId, id: trainingId } })
     if (!training) {
       throw new NotFoundError('Training not found.')
     }


### PR DESCRIPTION
Unlike the other models like Exile, Suspension & Ban, Training is the only one that is queried by id instead of userId. #224 implemented this wrong and used the column trainingId. This PR fixes that.