### PR TITLE
fix: don't migrate on no rows

### DIFF
--- a/db/migrations/20210412042113-merge-suspension-into-ban.js
+++ b/db/migrations/20210412042113-merge-suspension-into-ban.js
@@ -65,7 +65,7 @@ module.exports = {
 
         const banCancellations = getCancellations(insertedBans, suspensions, suspensionCancellations, 'ban')
         const banExtensions = getExtensions(insertedBans, suspensions, suspensionExtensions, 'ban')
-        if (banCancellations.length > 0 ) {
+        if (banCancellations.length > 0) {
           await queryInterface.bulkInsert('ban_cancellations', banCancellations, { transaction: t })
         }
         if (banExtensions.length > 0) {


### PR DESCRIPTION
Running #246's migration when there are no rows that need to be migrated caused an error, this PR adds checks to see if the migration inserts/deletes should happen.