### PR TITLE
fix: resolve minor database schema bugs

### DIFF
--- a/db/migrations/20200410195638-create-suspension.js
+++ b/db/migrations/20200410195638-create-suspension.js
@@ -16,10 +16,7 @@ module.exports = {
       },
       reason: {
         type: Sequelize.STRING,
-        allowNull: false,
-        validate: {
-          notEmpty: true
-        }
+        allowNull: false
       },
       date: {
         type: Sequelize.DATE,

--- a/db/migrations/20200410195902-create-training-cancellation.js
+++ b/db/migrations/20200410195902-create-training-cancellation.js
@@ -16,10 +16,7 @@ module.exports = {
       },
       reason: {
         type: Sequelize.STRING,
-        allowNull: false,
-        validate: {
-          notEmpty: true
-        }
+        allowNull: false
       },
       trainingId: {
         type: Sequelize.INTEGER,

--- a/db/migrations/20200410200215-create-suspension-cancellation.js
+++ b/db/migrations/20200410200215-create-suspension-cancellation.js
@@ -16,10 +16,7 @@ module.exports = {
       },
       reason: {
         type: Sequelize.STRING,
-        allowNull: false,
-        validate: {
-          notEmpty: true
-        }
+        allowNull: false
       },
       suspensionId: {
         type: Sequelize.INTEGER,

--- a/db/migrations/20200410200447-create-suspension-extension.js
+++ b/db/migrations/20200410200447-create-suspension-extension.js
@@ -16,10 +16,7 @@ module.exports = {
       },
       reason: {
         type: Sequelize.STRING,
-        allowNull: false,
-        validate: {
-          notEmpty: true
-        }
+        allowNull: false
       },
       duration: {
         type: Sequelize.INTEGER,

--- a/db/migrations/20200410234336-create-ban.js
+++ b/db/migrations/20200410234336-create-ban.js
@@ -16,10 +16,7 @@ module.exports = {
       },
       reason: {
         type: Sequelize.STRING,
-        allowNull: false,
-        validate: {
-          notEmpty: true
-        }
+        allowNull: false
       },
       rank: {
         type: Sequelize.INTEGER,

--- a/db/migrations/20200410234944-create-ban-cancellation.js
+++ b/db/migrations/20200410234944-create-ban-cancellation.js
@@ -16,10 +16,7 @@ module.exports = {
       },
       reason: {
         type: Sequelize.STRING,
-        allowNull: false,
-        validate: {
-          notEmpty: true
-        }
+        allowNull: false
       },
       banId: {
         type: Sequelize.INTEGER,

--- a/db/migrations/20210412183435-fix-constraints.js
+++ b/db/migrations/20210412183435-fix-constraints.js
@@ -1,0 +1,36 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface /* , Sequelize */) => {
+    return queryInterface.sequelize.transaction(async t => {
+      return Promise.all([
+        changeUserIdColumn(queryInterface, 'bans', 'author_id', true, t),
+        changeUserIdColumn(queryInterface, 'bans', 'user_id', true, t),
+        changeUserIdColumn(queryInterface, 'ban_cancellations', 'author_id', true, t),
+        changeUserIdColumn(queryInterface, 'training_cancellations', 'author_id', true, t),
+        changeUserIdColumn(queryInterface, 'trainings', 'author_id', true, t)
+      ])
+    })
+  },
+
+  down: (queryInterface /* , Sequelize */) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        changeUserIdColumn(queryInterface, 'bans', 'author_id', false, t),
+        changeUserIdColumn(queryInterface, 'bans', 'user_id', false, t),
+        changeUserIdColumn(queryInterface, 'ban_cancellations', 'author_id', false, t),
+        changeUserIdColumn(queryInterface, 'training_cancellations', 'author_id', false, t),
+        changeUserIdColumn(queryInterface, 'trainings', 'author_id', false, t)
+      ])
+    })
+  }
+}
+
+async function changeUserIdColumn (queryInterface, tableName, columnName, up, transaction) {
+  const attributes = await queryInterface.describeTable(tableName)
+  const attribute = attributes[columnName]
+  return queryInterface.changeColumn(tableName, columnName, {
+    type: attribute.type,
+    allowNull: !up
+  }, { transaction })
+}

--- a/db/migrations/20210412183435-fix-constraints.js
+++ b/db/migrations/20210412183435-fix-constraints.js
@@ -1,36 +1,46 @@
 'use strict'
 
 module.exports = {
-  up: (queryInterface /* , Sequelize */) => {
+  up: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction(async t => {
-      return Promise.all([
+      await Promise.all([
         changeUserIdColumn(queryInterface, 'bans', 'author_id', true, t),
         changeUserIdColumn(queryInterface, 'bans', 'user_id', true, t),
         changeUserIdColumn(queryInterface, 'ban_cancellations', 'author_id', true, t),
         changeUserIdColumn(queryInterface, 'training_cancellations', 'author_id', true, t),
         changeUserIdColumn(queryInterface, 'trainings', 'author_id', true, t)
       ])
+
+      return queryInterface.changeColumn('bans', 'date', {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn('NOW')
+      }, { transaction: t })
     })
   },
 
-  down: (queryInterface /* , Sequelize */) => {
-    return queryInterface.sequelize.transaction(t => {
-      return Promise.all([
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async t => {
+      await Promise.all([
         changeUserIdColumn(queryInterface, 'bans', 'author_id', false, t),
         changeUserIdColumn(queryInterface, 'bans', 'user_id', false, t),
         changeUserIdColumn(queryInterface, 'ban_cancellations', 'author_id', false, t),
         changeUserIdColumn(queryInterface, 'training_cancellations', 'author_id', false, t),
         changeUserIdColumn(queryInterface, 'trainings', 'author_id', false, t)
       ])
+
+      return queryInterface.changeColumn('bans', 'date', {
+        type: Sequelize.DATE,
+        allowNull: false
+      }, { transaction: t })
     })
   }
 }
 
 async function changeUserIdColumn (queryInterface, tableName, columnName, up, transaction) {
   const attributes = await queryInterface.describeTable(tableName)
-  const attribute = attributes[columnName]
   return queryInterface.changeColumn(tableName, columnName, {
-    type: attribute.type,
+    type: attributes[columnName].type,
     allowNull: !up
   }, { transaction })
 }


### PR DESCRIPTION
Adds a migration that fixes some small bugs with the database schema:

* removes unnecessary Sequelize-level validations
* makes `user_id` and `author_id` columns not nullable
* changes the defaultValue on db level of the bans.date column to NOW()

This PR resolves #248