### PR TITLE
feat: add status endpoint

### DIFF
--- a/src/controllers/v1/status.js
+++ b/src/controllers/v1/status.js
@@ -7,13 +7,21 @@ class StatusController {
     this._statusService = statusService
   }
 
-  async getStatus (req, res) {
-    res.json(await this._statusService.getStatus(req.params.groupId))
+  getStatus (req, res) {
+    res.json(this._statusService.getStatus())
+  }
+
+  async getGroupClientStatus (req, res) {
+    res.json(await this._statusService.getGroupClientStatus(req.params.groupId))
   }
 
   validate (method) {
     switch (method) {
       case 'getStatus':
+        return [
+          header('authorization').exists().isString()
+        ]
+      case 'getGroupClientStatus':
         return [
           header('authorization').exists().isString(),
           param('groupId').isInt().toInt()

--- a/src/routes/status.js
+++ b/src/routes/status.js
@@ -9,11 +9,18 @@ class StatusRouter {
     const router = express.Router()
 
     router.get(
-      '/:groupId',
+      '/',
       statusController.validate('getStatus'),
       handleValidationResult,
       authenticate,
       statusController.getStatus.bind(statusController)
+    )
+    router.get(
+      '/:groupId',
+      statusController.validate('getGroupClientStatus'),
+      handleValidationResult,
+      authenticate,
+      statusController.getGroupClientStatus.bind(statusController)
     )
 
     return router

--- a/src/services/status.js
+++ b/src/services/status.js
@@ -7,7 +7,13 @@ class StatusService {
     this._robloxManager = robloxManager
   }
 
-  async getStatus (groupId) {
+  getStatus () {
+    return {
+      state: 'running'
+    }
+  }
+
+  async getGroupClientStatus (groupId) {
     const client = this._robloxManager.getClient(groupId)
     if (!client) {
       throw new NotFoundError('Client not found.')


### PR DESCRIPTION
This PR adds a new endpoint `/v1/status` which will currently standard return an object with `state: "running"`. May add other information to this later.