### PR TITLE
feat: init Sentry with environment and release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,7 +36,7 @@ steps:
           username: buildkite
           password-env: DOCKER_PASSWORD
       - docker-compose#v3.7.0:
-          push: app-production:docker.guidojw.nl/arora/arora-api:staging
+          push: app-staging:docker.guidojw.nl/arora/arora-api:staging
           image-name: docker.guidojw.nl/arora/arora-api:staging
           config: docker-compose.buildkite.yml
 

--- a/docker-compose.buildkite.yml
+++ b/docker-compose.buildkite.yml
@@ -5,7 +5,12 @@ services:
     build:
       context: .
       args:
-        NODE_ENV: test
+        - NODE_ENV=test
 
-  app-production:
+  app-production: &production
     build: .
+    environment:
+      - BUILD_HASH=${BUILDKITE_COMMIT}
+
+  app-staging:
+    <<: *production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     restart: unless-stopped
     env_file: .env
     environment:
-      NODE_ENV: production
-      POSTGRES_HOST: db
+      - NODE_ENV=production
+      - POSTGRES_HOST=db
     volumes:
       - /opt/app/node_modules
       - /storage/backups:/storage/backups

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -9,7 +9,11 @@ const cronConfig = require('../../config/cron')
 
 async function init (app) {
   if (process.env.SENTRY_DSN) {
-    Sentry.init({ dsn: process.env.SENTRY_DSN })
+    Sentry.init({
+      dsn: process.env.SENTRY_DSN,
+      environment: process.env.NODE_ENV,
+      release: process.env.BUILD_HASH
+    })
   }
 
   const container = containerLoader()


### PR DESCRIPTION
This PR makes the CI build steps add environment variable `BUILD_HASH` to the build and sets the environment and release variables on Sentry init.