### PR TITLE
feat: improve HTTP errors

### DIFF
--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -4,5 +4,6 @@ module.exports = {
   ConflictError: require('./conflict'),
   ForbiddenError: require('./forbidden'),
   NotFoundError: require('./not-found'),
-  UnauthorizedError: require('./unauthorized')
+  UnauthorizedError: require('./unauthorized'),
+  UnprocessableError: require('./unprocessable')
 }

--- a/src/errors/unprocessable.js
+++ b/src/errors/unprocessable.js
@@ -1,0 +1,12 @@
+'use strict'
+
+class UnprocessableError extends Error {
+  constructor (message) {
+    super(message || 'Unprocessable')
+
+    this.name = this.constructor.name
+    this.statusCode = 422
+  }
+}
+
+module.exports = UnprocessableError

--- a/src/services/ban.js
+++ b/src/services/ban.js
@@ -2,7 +2,7 @@
 
 const pluralize = require('pluralize')
 
-const { ConflictError, ForbiddenError, NotFoundError } = require('../errors')
+const { ConflictError, ForbiddenError, NotFoundError, UnprocessableError } = require('../errors')
 const { inRange } = require('../util').util
 const { Ban, BanCancellation, BanExtension } = require('../models')
 
@@ -38,10 +38,10 @@ class BanService {
 
     const days = duration / (24 * 60 * 60 * 1000)
     if (days < 1) {
-      throw new ForbiddenError('Insufficient amount of days.')
+      throw new UnprocessableError('Insufficient amount of days.')
     }
     if (days > 7) {
-      throw new ForbiddenError('Too many days.')
+      throw new UnprocessableError('Too many days.')
     }
 
     const ban = await Ban.create({
@@ -78,7 +78,7 @@ class BanService {
   async extendBan (groupId, userId, { authorId, duration, reason }) {
     const ban = await this.getBan(groupId, userId)
     if (ban.duration === null) {
-      throw new ForbiddenError('Ban is permanent.')
+      throw new UnprocessableError('Ban is permanent.')
     }
 
     let newDuration = ban.duration
@@ -86,10 +86,10 @@ class BanService {
     newDuration += duration
     const days = newDuration / (24 * 60 * 60 * 1000)
     if (days < 1) {
-      throw new ForbiddenError('Insufficient amount of days.')
+      throw new UnprocessableError('Insufficient amount of days.')
     }
     if (days > 7) {
-      throw new ForbiddenError('Too many days.')
+      throw new UnprocessableError('Too many days.')
     }
 
     const extension = await BanExtension.create({

--- a/src/services/ban.js
+++ b/src/services/ban.js
@@ -3,6 +3,7 @@
 const pluralize = require('pluralize')
 
 const { ConflictError, ForbiddenError, NotFoundError, UnprocessableError } = require('../errors')
+const { hasScopes } = require('../util').requestUtil
 const { inRange } = require('../util').util
 const { Ban, BanCancellation, BanExtension } = require('../models')
 
@@ -15,12 +16,18 @@ class BanService {
     this._userService = userService
   }
 
-  getBans (groupId, scope, sort) {
-    return Ban.scope(scope ?? 'defaultScope').findAll({ where: { groupId }, order: sort })
+  getBans (groupId, scopes, sort) {
+    if (!hasScopes(Ban, scopes)) {
+      throw new UnprocessableError('Invalid scope.')
+    }
+    return Ban.scope(scopes ?? 'defaultScope').findAll({ where: { groupId }, order: sort })
   }
 
-  async getBan (groupId, userId, scope) {
-    const ban = await Ban.scope(scope ?? 'defaultScope').findOne({ where: { groupId, userId } })
+  async getBan (groupId, userId, scopes) {
+    if (!hasScopes(Ban, scopes)) {
+      throw new UnprocessableError('Invalid scope.')
+    }
+    const ban = await Ban.scope(scopes ?? 'defaultScope').findOne({ where: { groupId, userId } })
     if (!ban) {
       throw new NotFoundError('Ban not found.')
     }

--- a/src/services/exile.js
+++ b/src/services/exile.js
@@ -31,7 +31,7 @@ class ExileService {
     }
     const rank = await this._groupService.getRank(groupId, userId)
     if (applicationConfig.unexilableRanks.some(range => inRange(rank, range))) {
-      throw new ForbiddenError('Cannot exile members on this role.')
+      throw new ForbiddenError('User\'s role is unexilable.')
     }
 
     try {

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -28,7 +28,16 @@ function decodeSortQueryParam (param = '') {
     : undefined
 }
 
+function hasScopes (model, scopes) {
+  if (typeof scopes === 'undefined') {
+    return true
+  }
+  const modelScopes = ['defaultScope', ...Object.values(model.options.scopes)]
+  return scopes.every(scope => modelScopes.includes(scope))
+}
+
 module.exports = {
   decodeScopeQueryParam,
-  decodeSortQueryParam
+  decodeSortQueryParam,
+  hasScopes
 }

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -32,7 +32,7 @@ function hasScopes (model, scopes) {
   if (typeof scopes === 'undefined') {
     return true
   }
-  const modelScopes = ['defaultScope', ...Object.values(model.options.scopes)]
+  const modelScopes = ['defaultScope', ...Object.keys(model.options.scopes)]
   return scopes.every(scope => modelScopes.includes(scope))
 }
 


### PR DESCRIPTION
This PR adds a new HTTP error `422 Unprocessable` and changes some of the thrown errors in the services to the proper ones for those cases.

Also a check is implemented before using scopes on models which checks if the requested scopes exist and throws above unprocessable error otherwise.

For Sentry:
Fixes ARORA-API-38
Fixes ARORA-API-39