### PR TITLE
fix: improve timezone string RegEx

### DIFF
--- a/src/util/time.js
+++ b/src/util/time.js
@@ -15,7 +15,7 @@ function getTime (date) {
 
 function getTimeZoneAbbreviation (date) {
   return date.toLocaleTimeString('en-us', { hour12: false, hour: '2-digit', minute: '2-digit', timeZoneName: 'long' })
-    .replace(/^(2[0-3]|[0-1]?\d):[0-5]\d\s/, '')
+    .replace(/([a-z]+(\s[a-z]+)*)$/i, '')
     .split(' ')
     .filter(word => word !== 'Standard')
     .map(word => word.charAt(0))


### PR DESCRIPTION
The timezone in automatic training shouts oddly included a random 2 at times (like "2CEST"), with this RegEx change that will hopefully be fixed.