### PR TITLE
fix: allow hour 24 in timezone regex

### DIFF
--- a/src/util/time.js
+++ b/src/util/time.js
@@ -15,7 +15,7 @@ function getTime (date) {
 
 function getTimeZoneAbbreviation (date) {
   return date.toLocaleTimeString('en-us', { hour12: false, hour: '2-digit', minute: '2-digit', timeZoneName: 'long' })
-    .replace(/([a-z]+(\s[a-z]+)*)$/i, '')
+    .replace(/^(2[0-4]|[0-1][1-9]):[0-5]\d\s/, '')
     .split(' ')
     .filter(word => word !== 'Standard')
     .map(word => word.charAt(0))


### PR DESCRIPTION
Found out the locale timestring goes from 23:59 to 24:00 instead of 00:00.