### PR TITLE
Revert "fix: move typescript to dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,7 @@
     "node-schedule": "^2.0.0",
     "pg": "^8.6.0",
     "pluralize": "^8.0.0",
-    "reflect-metadata": "^0.1.13",
     "typeorm": "^0.2.32",
-    "typescript": "^4.2.4",
     "ws": "^7.4.5"
   },
   "devDependencies": {
@@ -62,7 +60,9 @@
     "eslint-config-standard-with-typescript": "^20.0.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.1.0"
+    "eslint-plugin-promise": "^5.1.0",
+    "reflect-metadata": "^0.1.13",
+    "typescript": "^4.2.4"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
Reverts guidojw/arora-api#269

Use another strategy with Docker, probably multistaged builds.