### PR TITLE
fix(Dockerfile): install correct deps for building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN yarn build-bloxy && yarn build
 
 RUN if [ "$NODE_ENV" = 'production' ] || [ "$NODE_ENV" = 'staging' ]; then \
-    yarn install --frozen-lockfile --production=true \
+    yarn install --frozen-lockfile --production=true; \
   fi
 
 RUN chmod +x ./bin/wait-for-it.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,6 @@ RUN yarn install --frozen-lockfile --production=false
 COPY . .
 RUN yarn build-bloxy && yarn build
 
-RUN if [ "$NODE_ENV" = 'production' ] || [ "$NODE_ENV" = 'staging' ]; then \
-    yarn install --frozen-lockfile --production=true; \
-  fi
-
 RUN chmod +x ./bin/wait-for-it.sh
 
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,14 @@ ENV BUILD_HASH=$BUILD_HASH
 
 WORKDIR /opt/app
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile \
-  $([ "$NODE_ENV" = 'production' ] || [ "$NODE_ENV" = 'staging' ] && printf %s '--production=true')
+RUN yarn install --frozen-lockfile --production=false
 
 COPY . .
 RUN yarn build-bloxy && yarn build
+
+RUN if [ "$NODE_ENV" = 'production' ] || [ "$NODE_ENV" = 'staging' ]; then \
+    yarn install --frozen-lockfile --production=true \
+  fi
 
 RUN chmod +x ./bin/wait-for-it.sh
 


### PR DESCRIPTION
The Docker image building stage needs the devDependencies in order for TypeScript compilationto work. 

This PR makes the `yarn install` step install all dependencies **always**. In the future to reduce image size I want to upgrade Yarn to v2 and make use of the plugin prod-installs to remove the devDependencies after TypeScript compilation.