### PR TITLE
fix: ban scopes and order

### DIFF
--- a/src/jobs/announce-trainings.ts
+++ b/src/jobs/announce-trainings.ts
@@ -19,8 +19,8 @@ export default class AnnounceTrainingsJob implements BaseJob {
   async run (groupId?: number): Promise<any> {
     if (typeof groupId === 'undefined') {
       const groupIds = (await this.trainingRepository.scopes.default
-        .select('DISTINCT training.groupId')
-        .addGroupBy('training.groupId')
+        .select('DISTINCT training.group_id')
+        .addGroupBy('training.group_id')
         .getMany()
       ).map(training => training.groupId)
       return Promise.all(groupIds.map(async groupId => await this.run(groupId)))

--- a/src/repositories/ban.ts
+++ b/src/repositories/ban.ts
@@ -34,7 +34,7 @@ export class BanScopes extends BaseScopes<Ban> {
       .addSelect('ban.*')
       .addSelect('"other_ban".ends_at')
       .leftJoin('ban_cancellations', 'cancellation', 'cancellation.ban_id = ban.id')
-      .leftJoin(BanScopes.makeExtensionsTotalDurationQueryBuilder, 'other_ban', '"other_ban".id = ban.id')
+      .leftJoin(BanScopes.makeEndsAtQueryBuilder, 'other_ban', '"other_ban".id = ban.id')
       .leftJoinAndSelect('ban_extensions', 'extension', 'extension.ban_id = ban.id')
       .andWhere('cancellation.id IS NULL')
       .addGroupBy('ban.id')
@@ -48,7 +48,7 @@ export class BanScopes extends BaseScopes<Ban> {
       .addSelect('ban.*')
       .addSelect('"other_ban".ends_at')
       .leftJoin('ban_cancellations', 'cancellation', 'cancellation.ban_id = ban.id')
-      .leftJoin(BanScopes.makeExtensionsTotalDurationQueryBuilder, 'other_ban', '"other_ban".id = ban.id')
+      .leftJoin(BanScopes.makeEndsAtQueryBuilder, 'other_ban', '"other_ban".id = ban.id')
       .leftJoinAndSelect('ban_extensions', 'extension', 'extension.ban_id = ban.id')
       .andWhere('cancellation.id IS NULL')
       .addGroupBy('ban.id')
@@ -57,7 +57,7 @@ export class BanScopes extends BaseScopes<Ban> {
       .orHaving('(ban.duration IS NULL OR other_ban.ends_at <= NOW())')
   }
 
-  private static makeExtensionsTotalDurationQueryBuilder (qb: SelectQueryBuilder<any>): SelectQueryBuilder<any> {
+  private static makeEndsAtQueryBuilder (qb: SelectQueryBuilder<any>): SelectQueryBuilder<any> {
     // Connection is somehow undefined on this qb, and repository is a connection instance so weird fix but works?
     // @ts-expect-error
     qb.connection = qb.repository

--- a/src/repositories/ban.ts
+++ b/src/repositories/ban.ts
@@ -1,6 +1,6 @@
 import BaseRepository, { BaseScopes } from './base'
+import { EntityRepository, SelectQueryBuilder } from 'typeorm'
 import { Ban } from '../entities'
-import { EntityRepository } from 'typeorm'
 
 const endsAtLiteral = 'date + ' +
   '(ban.duration||\' milliseconds\')::INTERVAL + ' +
@@ -31,25 +31,42 @@ export class BanScopes extends BaseScopes<Ban> {
 
   get default (): this {
     return this
-      .select(`ban.*, ${endsAtLiteral} AS ends_at`)
-      .leftJoinAndSelect('ban_cancellations', 'cancellation', 'cancellation.banId = ban.id')
-      .leftJoinAndSelect('ban_extensions', 'extension', 'extension.banId = ban.id')
+      .addSelect('ban.*')
+      .addSelect('"other_ban".ends_at')
+      .leftJoin('ban_cancellations', 'cancellation', 'cancellation.ban_id = ban.id')
+      .leftJoin(BanScopes.makeExtensionsTotalDurationQueryBuilder, 'other_ban', '"other_ban".id = ban.id')
+      .leftJoinAndSelect('ban_extensions', 'extension', 'extension.ban_id = ban.id')
       .andWhere('cancellation.id IS NULL')
       .addGroupBy('ban.id')
-      .addGroupBy('cancellation.id')
       .addGroupBy('extension.id')
-      .andHaving(`ban.duration IS NULL OR ${endsAtLiteral} > NOW()`)
+      .addGroupBy('"other_ban".ends_at')
+      .orHaving('(ban.duration IS NULL OR other_ban.ends_at > NOW())')
   }
 
   get finished (): this {
     return this
-      .select(`ban.*, ${endsAtLiteral} AS ends_at`)
-      .leftJoinAndSelect('ban_cancellations', 'cancellation', 'cancellation.banId = ban.id')
-      .leftJoinAndSelect('ban_extensions', 'extension', 'extension.banId = ban.id')
+      .addSelect('ban.*')
+      .addSelect('"other_ban".ends_at')
+      .leftJoin('ban_cancellations', 'cancellation', 'cancellation.ban_id = ban.id')
+      .leftJoin(BanScopes.makeExtensionsTotalDurationQueryBuilder, 'other_ban', '"other_ban".id = ban.id')
+      .leftJoinAndSelect('ban_extensions', 'extension', 'extension.ban_id = ban.id')
       .andWhere('cancellation.id IS NULL')
       .addGroupBy('ban.id')
-      .addGroupBy('cancellation.id')
       .addGroupBy('extension.id')
-      .andHaving(`ban.duration IS NULL OR ${endsAtLiteral} <= NOW()`)
+      .addGroupBy('other_ban.ends_at')
+      .orHaving('(ban.duration IS NULL OR other_ban.ends_at <= NOW())')
+  }
+
+  private static makeExtensionsTotalDurationQueryBuilder (qb: SelectQueryBuilder<any>): SelectQueryBuilder<any> {
+    // Connection is somehow undefined on this qb, and repository is a connection instance so weird fix but works?
+    // @ts-expect-error
+    qb.connection = qb.repository
+    return qb
+      .select(endsAtLiteral, 'ends_at')
+      .addSelect('ban.id', 'id')
+      .from('bans', 'ban')
+      .addFrom('ban_extensions', 'extension')
+      .groupBy('ban.id')
+      .addGroupBy('ban.date')
   }
 }

--- a/src/repositories/ban.ts
+++ b/src/repositories/ban.ts
@@ -32,23 +32,23 @@ export class BanScopes extends BaseScopes<Ban> {
   get default (): this {
     return this
       .addSelect('ban.*')
-      .addSelect('"other_ban".ends_at')
+      .addSelect('other_ban.ends_at')
       .leftJoin('ban_cancellations', 'cancellation', 'cancellation.ban_id = ban.id')
-      .leftJoin(BanScopes.makeEndsAtQueryBuilder, 'other_ban', '"other_ban".id = ban.id')
+      .leftJoin(BanScopes.makeEndsAtQueryBuilder, 'other_ban', 'other_ban.id = ban.id')
       .leftJoinAndSelect('ban_extensions', 'extension', 'extension.ban_id = ban.id')
       .andWhere('cancellation.id IS NULL')
       .addGroupBy('ban.id')
       .addGroupBy('extension.id')
-      .addGroupBy('"other_ban".ends_at')
+      .addGroupBy('other_ban.ends_at')
       .orHaving('(ban.duration IS NULL OR other_ban.ends_at > NOW())')
   }
 
   get finished (): this {
     return this
       .addSelect('ban.*')
-      .addSelect('"other_ban".ends_at')
+      .addSelect('other_ban.ends_at')
       .leftJoin('ban_cancellations', 'cancellation', 'cancellation.ban_id = ban.id')
-      .leftJoin(BanScopes.makeEndsAtQueryBuilder, 'other_ban', '"other_ban".id = ban.id')
+      .leftJoin(BanScopes.makeEndsAtQueryBuilder, 'other_ban', 'other_ban.id = ban.id')
       .leftJoinAndSelect('ban_extensions', 'extension', 'extension.ban_id = ban.id')
       .andWhere('cancellation.id IS NULL')
       .addGroupBy('ban.id')

--- a/src/repositories/payout.ts
+++ b/src/repositories/payout.ts
@@ -7,10 +7,11 @@ export default class PayoutRepository extends Repository<Payout> {
     return (await this
       .createQueryBuilder('payout')
       .innerJoin(qb => (
-        qb.from('payouts', 'otherPayout')
-          .select('MAX(otherPayout.until)', 'until')
-      ), 'otherPayout', '"otherPayout".until = payout.until')
-      .andWhere('payout.groupId = :groupId', { groupId })
+        qb
+          .from('payouts', 'other_payout')
+          .select('MAX(other_payout.until)', 'until')
+      ), 'other_payout', 'other_payout.until = payout.until')
+      .andWhere('payout.group_id = :groupId', { groupId })
       .getOne()
     )
   }

--- a/src/repositories/training.ts
+++ b/src/repositories/training.ts
@@ -24,9 +24,9 @@ export default class TrainingRepository extends BaseRepository<Training> {
 export class TrainingScopes extends BaseScopes<Training> {
   get default (): this {
     return this
-      .select('training.*')
+      .addSelect('training.*')
       .leftJoinAndSelect('training.type', 'type')
-      .leftJoinAndSelect('training_cancellations', 'cancellation', 'cancellation.trainingId = training.id')
+      .leftJoin('training_cancellations', 'cancellation', 'cancellation.training_id = training.id')
       .andWhere('cancellation.id IS NULL')
       .andWhere('training.date > NOW() - INTERVAL \'15 minutes\'')
   }

--- a/src/services/ban.ts
+++ b/src/services/ban.ts
@@ -29,7 +29,7 @@ export default class BanService {
     }
 
     const qb = this.banRepository.scopes.apply(scopes)
-      .andWhere('ban.groupId = :groupId', { groupId })
+      .andWhere('ban.group_id = :groupId', { groupId })
     if (typeof sort !== 'undefined') {
       sort.forEach(s => qb.addOrderBy(...s))
     }
@@ -43,8 +43,8 @@ export default class BanService {
     }
 
     const ban = await this.banRepository.scopes.apply(scopes)
-      .andWhere('ban.groupId = :groupId', { groupId })
-      .andWhere('ban.userId = :userId', { userId })
+      .andWhere('ban.group_id = :groupId', { groupId })
+      .andWhere('ban.user_id = :userId', { userId })
       .getOne()
 
     if (typeof ban === 'undefined') {

--- a/src/services/training.ts
+++ b/src/services/training.ts
@@ -29,7 +29,7 @@ export default class TrainingService {
     }
 
     const qb = this.trainingRepository.scopes.apply(scopes)
-      .andWhere('training.groupId = :groupId', { groupId })
+      .andWhere('training.group_id = :groupId', { groupId })
     if (typeof sort !== 'undefined') {
       sort.forEach(s => qb.addOrderBy(...s))
     }
@@ -43,7 +43,7 @@ export default class TrainingService {
     }
 
     const training = await this.trainingRepository.scopes.apply(scopes)
-      .andWhere('training.groupId = :groupId', { groupId })
+      .andWhere('training.group_id = :groupId', { groupId })
       .andWhere('training.id = :id', { id })
       .getOne()
 

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -5,3 +5,17 @@ export function inRange (value: number, range: Range): boolean {
     ? range === value
     : (range[0] ?? 0) <= value && value <= (range[1] ?? 255)
 }
+
+// groupBy that preserves the records' order by returning an array instead of an object.
+export function groupBy<T> (records: T[], key: string): T[][] {
+  const result: T[][] = []
+  for (const record of records) {
+    const recordGroup = result.find(group => (group[0] as any)[key] === (record as any)[key])
+    if (typeof recordGroup === 'undefined') {
+      result.push([record])
+    } else {
+      recordGroup.push(record)
+    }
+  }
+  return result
+}


### PR DESCRIPTION
This PR fixes the ban scopes not calculating `endsAt` properly and fixes the bug where the order wasn't preserverd through lodash.groupBy.

Some other minor improvements related to the repositories and scopes were made as well.