### PR TITLE
fix: call correct scopes & return empty extensions

### DIFF
--- a/src/repositories/ban.ts
+++ b/src/repositories/ban.ts
@@ -13,14 +13,16 @@ export default class BanRepository extends BaseRepository<Ban> {
   }
 
   transform (record: any): Ban {
-    if (record.extension_id != null) {
-      record.extensions = [{
-        id: record.extension_id,
-        author_id: record.extension_author_id,
-        ban_id: record.extension_ban_id,
-        duration: record.extension_duration,
-        reason: record.extension_reason
-      }]
+    if (typeof record.extension_id !== 'undefined') {
+      record.extensions = record.extension_id === null
+        ? []
+        : [{
+            id: record.extension_id,
+            author_id: record.extension_author_id,
+            ban_id: record.extension_ban_id,
+            duration: record.extension_duration,
+            reason: record.extension_reason
+          }]
     }
     return super.transform(record)
   }

--- a/src/services/ban.ts
+++ b/src/services/ban.ts
@@ -58,7 +58,11 @@ export default class BanService {
     userId: number,
     { authorId, duration, reason }: { authorId: number, duration?: number | null, reason: string }
   ): Promise<Ban> {
-    if (typeof await this.banRepository.findOne({ where: { groupId, userId } }) !== 'undefined') {
+    if (typeof await this.banRepository.scopes.default
+      .andWhere('ban.group_id = :groupId', { groupId })
+      .andWhere('ban.user_id = :userId', { userId })
+      .getOne() !== 'undefined'
+    ) {
       throw new ConflictError('User is already banned.')
     }
     const role = await this.groupService.getRole(groupId, userId)

--- a/src/services/ban.ts
+++ b/src/services/ban.ts
@@ -18,7 +18,7 @@ const { inRange } = util
 export default class BanService {
   @inject(TYPES.DiscordMessageJob) private readonly discordMessageJob!: DiscordMessageJob
   @inject(TYPES.BanRepository) private readonly banRepository!: BanRepository
-  @inject(TYPES.BanRepository) private readonly banCancellationRepository!: Repository<BanCancellation>
+  @inject(TYPES.BanCancellationRepository) private readonly banCancellationRepository!: Repository<BanCancellation>
   @inject(TYPES.BanExtensionRepository) private readonly banExtensionRepository!: Repository<BanExtension>
   @inject(TYPES.GroupService) private readonly groupService!: GroupService
   @inject(TYPES.UserService) private readonly userService!: UserService


### PR DESCRIPTION
Continuation on #275, calls the correct scopes to check if a user is already banned and returns empty array of extensions instead of undefined when a ban has no extensions.