### PR TITLE
fix(BanRepository): use seconds instead of ms in intervals

### DIFF
--- a/src/repositories/ban.ts
+++ b/src/repositories/ban.ts
@@ -4,7 +4,7 @@ import { Ban } from '../entities'
 
 const endsAtLiteral = 'date + ' +
   '(ban.duration||\' milliseconds\')::INTERVAL + ' +
-  '(COALESCE(SUM(extension.duration), 0)||\' milliseconds\')::INTERVAL'
+  '(COALESCE(SUM(extension.duration) / 1000, 0)||\' seconds\')::INTERVAL'
 
 @EntityRepository(Ban)
 export default class BanRepository extends BaseRepository<Ban> {

--- a/src/repositories/ban.ts
+++ b/src/repositories/ban.ts
@@ -2,9 +2,9 @@ import BaseRepository, { BaseScopes } from './base'
 import { EntityRepository, SelectQueryBuilder } from 'typeorm'
 import { Ban } from '../entities'
 
-const endsAtLiteral = 'date + ' +
-  '(ban.duration||\' milliseconds\')::INTERVAL + ' +
-  '(COALESCE(SUM(extension.duration) / 1000, 0)||\' seconds\')::INTERVAL'
+const endsAtLiteral = 'ban.date + ' +
+  '(ban.duration / 1000||\' seconds\')::INTERVAL + ' +
+  '(SUM(extension.duration) / 1000||\' seconds\')::INTERVAL'
 
 @EntityRepository(Ban)
 export default class BanRepository extends BaseRepository<Ban> {


### PR DESCRIPTION
Got an out of range error when using this on production data (7 days in milliseconds probably overflows it).