### PR TITLE
fix: instantiate entities on repository.save

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -20,7 +20,7 @@ export default class AuthService {
     return jwt.sign(payload, privateKey, { algorithm: 'RS256' })
   }
 
-  private verify (token: string): string | object {
+  public verify (token: string): string | object {
     return jwt.verify(token, publicKey, { algorithms: ['RS256'] })
   }
 }

--- a/src/services/ban.ts
+++ b/src/services/ban.ts
@@ -81,14 +81,14 @@ export default class BanService {
       }
     }
 
-    const ban = await this.banRepository.save({
+    const ban = await this.banRepository.save(this.banRepository.create({
       authorId,
       duration,
       groupId,
       reason,
       roleId: role.id,
       userId
-    })
+    }))
 
     const [authorName, username] = await Promise.all([
       this.userService.getUsername(ban.authorId),
@@ -105,7 +105,11 @@ export default class BanService {
     { authorId, reason }: { authorId: number, reason: string }
   ): Promise<BanCancellation> {
     const ban = await this.getBan(groupId, userId)
-    const cancellation = await this.banCancellationRepository.save({ banId: ban.id, authorId, reason })
+    const cancellation = await this.banCancellationRepository.save(this.banCancellationRepository.create({
+      banId: ban.id,
+      authorId,
+      reason
+    }))
 
     const [authorName, username] = await Promise.all([
       this.userService.getUsername(cancellation.authorId),
@@ -137,12 +141,12 @@ export default class BanService {
       throw new UnprocessableError('Too many days.')
     }
 
-    const extension = await this.banExtensionRepository.save({
+    const extension = await this.banExtensionRepository.save(this.banExtensionRepository.create({
       authorId,
       banId: ban.id,
       duration,
       reason
-    })
+    }))
 
     const [authorName, username] = await Promise.all([
       this.userService.getUsername(extension.authorId),

--- a/src/services/exile.ts
+++ b/src/services/exile.ts
@@ -46,7 +46,12 @@ export default class ExileService {
     try {
       await this.groupService.kickMember(groupId, userId)
     } catch {} // eslint-disable-line no-empty
-    const exile = await this.exileRepository.save({ authorId, groupId, reason, userId })
+    const exile = await this.exileRepository.save(this.exileRepository.create({
+      authorId,
+      groupId,
+      reason,
+      userId
+    }))
 
     const [username, authorName] = await Promise.all([
       this.userService.getUsername(exile.userId),

--- a/src/services/training.ts
+++ b/src/services/training.ts
@@ -58,13 +58,13 @@ export default class TrainingService {
     { typeId, authorId, date, notes }: { typeId: number, authorId: number, date: number, notes?: string | null }
   ): Promise<Training> {
     const trainingType = await this.getTrainingType(groupId, typeId)
-    const training = await this.trainingRepository.save({
+    const training = await this.trainingRepository.save(this.trainingRepository.create({
       groupId,
       authorId,
       typeId,
       date: new Date(date),
       notes
-    })
+    }))
     training.type = trainingType
 
     await this.announceTrainingsJob.run(groupId)
@@ -151,7 +151,11 @@ export default class TrainingService {
     { authorId, reason }: { authorId: number, reason: string }
   ): Promise<TrainingCancellation> {
     const training = await this.getTraining(groupId, id)
-    const cancellation = await this.trainingCancellationRepository.save({ trainingId: training.id, authorId, reason })
+    const cancellation = await this.trainingCancellationRepository.save(this.trainingCancellationRepository.create({
+      trainingId: training.id,
+      authorId,
+      reason
+    }))
 
     await this.announceTrainingsJob.run(groupId)
     const job = cron.scheduledJobs[`training_${cancellation.trainingId}`]
@@ -187,7 +191,11 @@ export default class TrainingService {
       throw new ConflictError('A training type with that name already exists.')
     }
 
-    return await this.trainingTypeRepository.save({ groupId, name, abbreviation })
+    return await this.trainingTypeRepository.save(this.trainingTypeRepository.create({
+      groupId,
+      name,
+      abbreviation
+    }))
   }
 
   public async changeTrainingType (


### PR DESCRIPTION
Convert objects to entities themselves on saving to repository so that the ValidationSubscriber actually knows what to validate.