### PR TITLE
refactor(controllers): make all controllers extend BaseHttpController

### DIFF
--- a/src/controllers/v1/catalog.ts
+++ b/src/controllers/v1/catalog.ts
@@ -1,5 +1,11 @@
+import {
+  BaseHttpController,
+  controller,
+  httpGet,
+  interfaces,
+  results
+} from 'inversify-express-utils'
 import { ValidationChain, header, query } from 'express-validator'
-import { controller, httpGet, interfaces } from 'inversify-express-utils'
 import { CatalogService } from '../../services'
 import { Request } from 'express'
 import { constants } from '../../util'
@@ -8,16 +14,16 @@ import { inject } from 'inversify'
 const { TYPES } = constants
 
 @controller('/v1/catalog')
-export default class CatalogController implements interfaces.Controller {
+export default class CatalogController extends BaseHttpController implements interfaces.Controller {
   @inject(TYPES.CatalogService) private readonly catalogService!: CatalogService
 
   @httpGet('/', ...CatalogController.validate('getItems'), TYPES.ErrorMiddleware, TYPES.AuthMiddleware)
-  public async getItems (req: Request): Promise<object[]> {
+  public async getItems (req: Request): Promise<results.JsonResult> {
     const queryStart = req.originalUrl.indexOf('?')
     const queryString = queryStart > 0
       ? req.originalUrl.slice(queryStart + 1)
       : ''
-    return await this.catalogService.getItems(queryString)
+    return this.json(await this.catalogService.getItems(queryString))
   }
 
   private static validate (method: string): ValidationChain[] {

--- a/src/controllers/v1/status.ts
+++ b/src/controllers/v1/status.ts
@@ -1,5 +1,12 @@
+import {
+  BaseHttpController,
+  controller,
+  httpGet,
+  interfaces,
+  requestParam,
+  results
+} from 'inversify-express-utils'
 import { ValidationChain, header, param } from 'express-validator'
-import { controller, httpGet, interfaces, requestParam } from 'inversify-express-utils'
 import { GetStatus } from '../../services/status'
 import { StatusService } from '../../services'
 import { constants } from '../../util'
@@ -8,7 +15,7 @@ import { inject } from 'inversify'
 const { TYPES } = constants
 
 @controller('/v1/status')
-export default class StatusController implements interfaces.Controller {
+export default class StatusController extends BaseHttpController implements interfaces.Controller {
   @inject(TYPES.StatusService) private readonly statusService!: StatusService
 
   @httpGet('/', ...StatusController.validate('getStatus'), TYPES.ErrorMiddleware, TYPES.AuthMiddleware)
@@ -22,8 +29,8 @@ export default class StatusController implements interfaces.Controller {
     TYPES.ErrorMiddleware,
     TYPES.AuthMiddleware
   )
-  public async getGroupClientStatus (@requestParam('groupId') groupId: number): Promise<boolean> {
-    return await this.statusService.getGroupClientStatus(groupId)
+  public async getGroupClientStatus (@requestParam('groupId') groupId: number): Promise<results.JsonResult> {
+    return this.json(await this.statusService.getGroupClientStatus(groupId))
   }
 
   private static validate (method: string): ValidationChain[] {


### PR DESCRIPTION
This PR makes all controllers extends inversify-express-utils' BaseHttpController for better future testability.

Resolves #293 