### PR TITLE
fix(Renovate): use replace strategy instead of pin and group non-major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
-  "extends": [
-    "config:base"
-  ],
-  "labels": ["dependencies"]
+  "extends": ["config:base"],
+  "labels": ["dependencies"],
+  "rangeStrategy": "replace"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,13 @@
 {
   "extends": ["config:base"],
   "labels": ["dependencies"],
-  "rangeStrategy": "replace"
+  "rangeStrategy": "replace",
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["*"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"groupName": "all non-major dependencies",
+			"groupSlug": "all-minor-patch"
+    }
+  ]
 }


### PR DESCRIPTION
Changes the replace strategy from pinning to replace to have Renovate do the same as Depfu.