### PR TITLE
feat(axios): add axios-retry to retry failed requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "@guidojw/bloxy": "^5.7.5",
     "@sentry/node": "^6.12.0",
     "axios": "^0.21.4",
-    "@guidojw/bloxy": "^5.7.5",
+    "axios-retry": "^3.2.0",
     "class-transformer": "^0.4.0",
     "class-validator": "^0.13.1",
     "debug": "^4.3.2",

--- a/src/loaders/axios.ts
+++ b/src/loaders/axios.ts
@@ -2,8 +2,6 @@ import axios from 'axios'
 import axiosRetry from 'axios-retry'
 
 axiosRetry(axios, {
-  retryCondition: err => (
-    axiosRetry.isNetworkOrIdempotentRequestError(err) === true || err.response?.status === 429
-  ),
+  retryCondition: err => axiosRetry.isNetworkOrIdempotentRequestError(err) || err.response?.status === 429,
   retryDelay: axiosRetry.exponentialDelay
 })

--- a/src/loaders/axios.ts
+++ b/src/loaders/axios.ts
@@ -1,0 +1,9 @@
+import axios from 'axios'
+import axiosRetry from 'axios-retry'
+
+axiosRetry(axios, {
+  retryCondition: err => (
+    axiosRetry.isNetworkOrIdempotentRequestError(err) === true || err.response?.status === 429
+  ),
+  retryDelay: axiosRetry.exponentialDelay
+})

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -1,3 +1,4 @@
+import './axios'
 import * as Sentry from '@sentry/node'
 import { Application } from 'express'
 import { BaseJob } from '../jobs'

--- a/yarn.lock
+++ b/yarn.lock
@@ -554,6 +554,13 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+axios-retry@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.2.0.tgz#eb48e72f90b177fde62329b2896aa8476cfb90ba"
+  integrity sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==
+  dependencies:
+    is-retry-allowed "^1.1.0"
+
 axios@^0.21.4:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
@@ -1852,6 +1859,11 @@ is-regex@^1.1.3:
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
+
+is-retry-allowed@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
+  integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
 
 is-string@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Adds `axios-retry` as dependency that will retry failed requests that are:
- network errors
- 5xx errors on idempotent requests
- 429 requests

Requests will be retried 3 times max and the interval between requests is determined by exponential backoff.

Fixes #339 