### PR TITLE
fix(Renovate): nodejs package rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,14 +17,14 @@
     },
     {
       "matchManagers": ["dockerfile", "nvm"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "Node.js (non-major)",
-      "groupSlug": "nodejs"
+      "groupName": "Node.js",
+      "groupSlug": "nodejs",
+      "ignoreUnstable": false
     },
     {
       "matchManagers": ["dockerfile", "nvm"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "Node.js (major)",
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Node.js (non-major)",
       "groupSlug": "nodejs"
     }
   ],


### PR DESCRIPTION
Fixes the Renovate configuration to include nvm updates to unstable node versions.