### PR TITLE
fix(CD): remove concurrency due to reusable workflows limitation

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -8,9 +8,6 @@ on:
         required: false
         default: 'n'
 
-concurrency:
-  group: cd-${{ github.ref_name }}
-
 env:
   PROJECT_NAME: arora-api
   SENTRY_ORG: guidos-projects


### PR DESCRIPTION
Reusable workflows have a [limitation](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#limitations) where caller workflows cannot set called workflows' concurrency, so this PR removes it. Now several CD runs can run concurrently which is a pity but not that big of a problem I think.