### PR TITLE
fix(CI): remove concurrency due to reusable workflows limitation

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -8,6 +8,9 @@ on:
         required: false
         default: 'n'
 
+concurrency:
+  group: cd-${{ github.ref_name }}
+
 env:
   PROJECT_NAME: arora-api
   SENTRY_ORG: guidos-projects

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,10 +10,6 @@ on:
         required: false
         type: string
 
-concurrency:
-  group: ci-${{ github.ref_name }}
-  cancel-in-progress: true
-
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Related: #374
Apparently the limitation refers to called workflows instead of caller workflows.