### PR TITLE
fix: sourcemaps uploading and naming

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -99,7 +99,7 @@ jobs:
           environment: ${{ needs.metadata.outputs.stage }}
           finalize: false
           sourcemaps: sourcemaps
-          url_prefix: /opt/app/dist
+          url_prefix: ~/dist
 
   update_check_run:
     name: Update Check Run

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@guidojw/bloxy": "^5.7.6",
+    "@sentry/integrations": "^6.15.0",
     "@sentry/node": "^6.15.0",
     "axios": "^0.24.0",
     "axios-retry": "^3.2.4",

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node'
 import type { Application } from 'express'
 import type { BaseJob } from '../jobs'
 import type { BaseManager } from '../managers'
+import { RewriteFrames } from '@sentry/integrations'
 import { constants } from '../util'
 import containerLoader from './container'
 import cronConfig from '../configs/cron'
@@ -16,7 +17,12 @@ export async function init (): Promise<Application> {
     Sentry.init({
       dsn: process.env.SENTRY_DSN,
       environment: process.env.NODE_ENV,
-      release: process.env.BUILD_HASH
+      release: process.env.BUILD_HASH,
+      integrations: [
+        new RewriteFrames({
+          root: process.cwd()
+        })
+      ]
     })
   }
 

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-     "sourceMap": true,                     /* Generates corresponding '.map' file. */
-     "sourceRoot": "/",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-     "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+     "sourceMap": true,                       /* Generates corresponding '.map' file. */
+     "sourceRoot": "src",                     /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+     "inlineSources": true                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,6 +402,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/integrations@npm:^6.15.0":
+  version: 6.15.0
+  resolution: "@sentry/integrations@npm:6.15.0"
+  dependencies:
+    "@sentry/types": 6.15.0
+    "@sentry/utils": 6.15.0
+    localforage: ^1.8.1
+    tslib: ^1.9.3
+  checksum: 53f6461ff27722df97f9de112a2adc2a53f405b235ba540bf57bf23fb95e25ea32f02949d8e552356cfb78dc186454a0731fb1c52fe3c29f760d2377d30be507
+  languageName: node
+  linkType: hard
+
 "@sentry/minimal@npm:6.15.0":
   version: 6.15.0
   resolution: "@sentry/minimal@npm:6.15.0"
@@ -1010,6 +1022,7 @@ __metadata:
   resolution: "arora-api@workspace:."
   dependencies:
     "@guidojw/bloxy": ^5.7.6
+    "@sentry/integrations": ^6.15.0
     "@sentry/node": ^6.15.0
     "@types/debug": ^4.1.7
     "@types/express": ^4.17.13
@@ -2757,6 +2770,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immediate@npm:~3.0.5":
+  version: 3.0.6
+  resolution: "immediate@npm:3.0.6"
+  checksum: f9b3486477555997657f70318cc8d3416159f208bec4cca3ff3442fd266bc23f50f0c9bd8547e1371a6b5e82b821ec9a7044a4f7b944798b25aa3cc6d5e63e62
+  languageName: node
+  linkType: hard
+
 "import-fresh@npm:^3.0.0, import-fresh@npm:^3.2.1":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
@@ -3217,10 +3237,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lie@npm:3.1.1":
+  version: 3.1.1
+  resolution: "lie@npm:3.1.1"
+  dependencies:
+    immediate: ~3.0.5
+  checksum: 6da9f2121d2dbd15f1eca44c0c7e211e66a99c7b326ec8312645f3648935bc3a658cf0e9fa7b5f10144d9e2641500b4f55bd32754607c3de945b5f443e50ddd1
+  languageName: node
+  linkType: hard
+
 "lines-and-columns@npm:^1.1.6":
   version: 1.1.6
   resolution: "lines-and-columns@npm:1.1.6"
   checksum: 198a5436b1fa5cf703bae719c01c686b076f0ad7e1aafd95a58d626cabff302dc0414822126f2f80b58a8c3d66cda8a7b6da064f27130f87e1d3506d6dfd0d68
+  languageName: node
+  linkType: hard
+
+"localforage@npm:^1.8.1":
+  version: 1.10.0
+  resolution: "localforage@npm:1.10.0"
+  dependencies:
+    lie: 3.1.1
+  checksum: f2978b434dafff9bcb0d9498de57d97eba165402419939c944412e179cab1854782830b5ec196212560b22712d1dd03918939f59cf1d4fc1d756fca7950086cf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
After a lot of local testing last night (should've done that before the GH Actions PR), these changes seem to work and make Sentry show the correct files and paths.

The RewriteFrames plugin takes frames of the stack and removes a root (in this case `/opt/app`) from it, so the resulting frame would be `dist/...`, which can then be coupled to the sourcemaps that now also start with `~/dist`.
The sourceRoot in `tsconfig.production.json` was changed to `src` so that Sentry shows for example `src/index.ts` instead of `/index.ts`, which is more correct imo. With this, linking stack traces to source code can now also work (I linked `src/` to `src/`).