### PR TITLE
fix: fetch from every branch before diff check

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
+        with:
+          fetch-depth: 0
 
       - name: Get metadata
         id: get_metadata
@@ -46,7 +48,6 @@ jobs:
         run: |
           if [ $GITHUB_REF_NAME = 'main' ]; then
             if [ "${INPUT_MERGE,,}" = 'y' ]; then
-              git fetch origin staging
               if ! git diff origin/main origin/staging --exit-code; then
                 echo '::set-output name=has_diff::true'
               else


### PR DESCRIPTION
The original way I did it somehow used a very old commit SHA. This fix makes the checkout action fetch all history of all branches (and tags), which then makes the later occurring manual git fetch redundant.