### PR TITLE
fix: remove node_modules from volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     environment:
       - POSTGRES_HOST=db
     volumes:
-      - /opt/app/node_modules
       - ./private.key:/opt/app/private.key
       - ./public.key:/opt/app/public.key
     labels:


### PR DESCRIPTION
Fixes the bug where deploys do not get updated node_modules until they are stopped and restarted.