### PR TITLE
fix: set version in Sentry release action when from workflow call

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -171,6 +171,7 @@ jobs:
           SENTRY_PROJECT: ${{ env.PROJECT_NAME }}
         with:
           environment: ${{ needs.metadata.outputs.stage }}
+          version: ${{ needs.merge.outputs.sha }}
           set_commits: skip
 
       - name: Finish deployment

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.get_metadata.outputs.tag }}
+      stage: ${{ steps.get_metadata.outputs.stage }}
       build_args: ${{ steps.get_metadata.outputs.build_args }}
     steps:
       - name: Get metadata
@@ -102,6 +103,7 @@ jobs:
           environment: ${{ needs.metadata.outputs.stage }}
           finalize: false
           sourcemaps: sourcemaps
+          version: ${{ github.event.inputs.sha }}
           url_prefix: ~/dist
 
   update_check_run:


### PR DESCRIPTION
Sets the missing output of the metadata step in the Publish Image action and sets version in Publish Image and Continuous Delivery explicitly when it is either from a merge commit or the workflow was triggered via `workflow_call`.