### PR TITLE
fix: don't deploy Sentry release in Publish Image

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -25,7 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.get_metadata.outputs.tag }}
-      stage: ${{ steps.get_metadata.outputs.stage }}
       build_args: ${{ steps.get_metadata.outputs.build_args }}
     steps:
       - name: Get metadata
@@ -41,12 +40,8 @@ jobs:
             BUILD_ARGS='BUILD_HASH='$GITHUB_SHA
             if [ $GITHUB_REF_NAME = 'main' ]; then
               BUILD_ARGS+=$'\nNODE_ENV=production'
-
-              echo '::set-output name=stage::production'
             else
               BUILD_ARGS+=$'\nNODE_ENV=staging'
-
-              echo '::set-output name=stage::staging'
             fi
             BUILD_ARGS=${BUILD_ARGS//$'\n'/'%0A'}
             echo '::set-output name=build_args::'$BUILD_ARGS

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -100,7 +100,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_PROJECT: ${{ env.PROJECT_NAME }}
         with:
-          environment: ${{ needs.metadata.outputs.stage }}
           finalize: false
           sourcemaps: sourcemaps
           version: ${{ github.event.inputs.sha }}


### PR DESCRIPTION
Sentry's release action creates a deploy when environment is specified, which is not desired here. 
https://github.com/getsentry/action-release/blob/744e4b262278339b79fb39c8922efcae71e98e39/src/main.ts#L56