### PR TITLE
feat(CD): make SSH host variable

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -153,7 +153,7 @@ jobs:
         env:
           STAGE: ${{ needs.metadata.outputs.stage }}
         with:
-          host: guidojw.nl
+          host: ${{ secrets.SSH_HOST }}
           username: github-actions
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           envs: PROJECT_NAME,STAGE


### PR DESCRIPTION
Since the domain is now behind a Cloudflare tunnel, it cannot be used anymore. This PR fixes that by making it a secret.