### PR TITLE
fix: use new Roblox API endpoints in CatalogService

### DIFF
--- a/src/controllers/v1/catalog.ts
+++ b/src/controllers/v1/catalog.ts
@@ -31,13 +31,13 @@ export default class CatalogController extends BaseHttpController implements int
       case 'getItems':
         return [
           header('authorization').exists().isString(),
-          query('CatalogContext').optional().isInt().toInt(),
-          query('Category').optional().isInt().toInt(),
-          query('CreatorID').optional().isInt().toInt(),
-          query('ResultsPerPage').optional().isInt().toInt(),
-          query('Keyword').optional().isString(),
-          query('SortType').optional().isString(),
-          query('PageNumber').optional().isInt().toInt()
+          query('limit').optional().isInt().toInt(),
+          query('pageNumber').optional().isInt().toInt(),
+          query('keyword').optional().isString(),
+          query('creatorType').optional().isInt().toInt(),
+          query('creatorTargetId').optional().isInt().toInt(),
+          query('useCreatorWhitelist').optional().isBoolean(),
+          query('includeOnlyVerifiedCreators').optional().isBoolean()
         ]
 
       default:

--- a/src/controllers/v1/catalog.ts
+++ b/src/controllers/v1/catalog.ts
@@ -17,18 +17,18 @@ const { TYPES } = constants
 export default class CatalogController extends BaseHttpController implements interfaces.Controller {
   @inject(TYPES.CatalogService) private readonly catalogService!: CatalogService
 
-  @httpGet('/', ...CatalogController.validate('getItems'), TYPES.ErrorMiddleware, TYPES.AuthMiddleware)
-  public async getItems (req: Request): Promise<results.JsonResult> {
+  @httpGet('/', ...CatalogController.validate('getMusicAssets'), TYPES.ErrorMiddleware, TYPES.AuthMiddleware)
+  public async getMusicAssets (req: Request): Promise<results.JsonResult> {
     const queryStart = req.originalUrl.indexOf('?')
     const queryString = queryStart > 0
       ? req.originalUrl.slice(queryStart + 1)
       : ''
-    return this.json(await this.catalogService.getItems(queryString))
+    return this.json(await this.catalogService.getMusicAssets(queryString))
   }
 
   private static validate (method: string): ValidationChain[] {
     switch (method) {
-      case 'getItems':
+      case 'getMusicAssets':
         return [
           header('authorization').exists().isString(),
           query('limit').optional().isInt().toInt(),

--- a/src/managers/roblox.ts
+++ b/src/managers/roblox.ts
@@ -37,6 +37,10 @@ export default class RobloxManager implements BaseManager {
       ? this.authenticatedClients[groupId] ?? this.unauthenticatedClient
       : this.unauthenticatedClient
   }
+
+  public getAuthenticatedClient (): Client | undefined {
+    return Object.values(this.authenticatedClients)[0]
+  }
 }
 
 // Custom Bloxy requester that adapts Got requests to Axios.

--- a/src/services/catalog.ts
+++ b/src/services/catalog.ts
@@ -10,10 +10,10 @@ const { TYPES } = constants
 export default class CatalogService {
   @inject(TYPES.RobloxManager) private readonly robloxManager!: RobloxManager
 
-  public async getItems (queryString: string): Promise<{}> {
+  public async getMusicAssets (queryString: string): Promise<unknown> {
     const client = this.robloxManager.getAuthenticatedClient() ?? this.robloxManager.getClient()
     const api = new CatalogAPI(client)
-    return await api.getItems(queryString)
+    return await api.getMusicAssets(queryString)
   }
 }
 
@@ -25,11 +25,22 @@ class CatalogAPI extends BaseAPI {
     })
   }
 
-  public async getItems (queryString: string): Promise<{}> {
-    return (await this.request({
+  public async getMusicAssets (queryString: string): Promise<unknown> {
+    const result = (await this.request({
       requiresAuth: true,
       request: {
         path: `v1/marketplace/300?${queryString}`
+      },
+      json: true
+    })).body
+    return await this.getDetails(result.data.map((asset: { id: number }) => asset.id))
+  }
+
+  public async getDetails (assetIds: number[]): Promise<unknown> {
+    return (await this.request({
+      requiresAuth: true,
+      request: {
+        path: `v1/items/details?assetIds=${assetIds.join(',')}`
       },
       json: true
     })).body

--- a/src/services/catalog.ts
+++ b/src/services/catalog.ts
@@ -1,9 +1,37 @@
-import axios from 'axios'
-import { injectable } from 'inversify'
+import { inject, injectable } from 'inversify'
+import BaseAPI from '@guidojw/bloxy/dist/client/apis/BaseAPI'
+import type { Client } from '@guidojw/bloxy'
+import type { RobloxManager } from '../managers'
+import { constants } from '../util'
+
+const { TYPES } = constants
 
 @injectable()
 export default class CatalogService {
-  public async getItems (queryString: string): Promise<object[]> {
-    return (await axios.get<object[]>(`https://search.roblox.com/catalog/json?${queryString}`)).data
+  @inject(TYPES.RobloxManager) private readonly robloxManager!: RobloxManager
+
+  public async getItems (queryString: string): Promise<{}> {
+    const client = this.robloxManager.getAuthenticatedClient() ?? this.robloxManager.getClient()
+    const api = new CatalogAPI(client)
+    return await api.getItems(queryString)
+  }
+}
+
+class CatalogAPI extends BaseAPI {
+  public constructor (client: Client) {
+    super({
+      client,
+      baseUrl: 'https://apis.roblox.com/toolbox-service/'
+    })
+  }
+
+  public async getItems (queryString: string): Promise<{}> {
+    return (await this.request({
+      requiresAuth: true,
+      request: {
+        path: `v1/marketplace/300?${queryString}`
+      },
+      json: true
+    })).body
   }
 }


### PR DESCRIPTION
The old one doesn't work anymore for the APM sounds published to the Roblox account and returned empty arrays, Project: Railrunner didn't correctly handle this so kept spamming the endpoint. This is not the most elegant PR and I might restructure some things later, but I want to merge this quickly so I can get a Project: Railrunner update out.