### PR TITLE
fix: optional parameter types

### DIFF
--- a/src/controllers/v1/group.ts
+++ b/src/controllers/v1/group.ts
@@ -335,7 +335,7 @@ export default class GroupController extends BaseHttpController implements inter
     @requestParam('groupId') groupId: number,
       @requestParam('trainingId') trainingId: number,
       @requestBody() body: {
-        changes: { typeId?: number, date?: number, notes?: string, authorId?: number }
+        changes: { typeId?: number, date?: number, notes?: string | null, authorId?: number }
         editorId: number
       }
   ): Promise<results.JsonResult> {

--- a/src/services/ban.ts
+++ b/src/services/ban.ts
@@ -56,7 +56,7 @@ export default class BanService {
   public async ban (
     groupId: number,
     userId: number,
-    { authorId, duration, reason }: { authorId: number, duration?: number | null, reason: string }
+    { authorId, duration, reason }: { authorId: number, duration?: number, reason: string }
   ): Promise<Ban> {
     if (typeof await this.banRepository.scopes.default
       .andWhere('ban.group_id = :groupId', { groupId })

--- a/src/services/training.ts
+++ b/src/services/training.ts
@@ -55,7 +55,7 @@ export default class TrainingService {
 
   public async addTraining (
     groupId: number,
-    { typeId, authorId, date, notes }: { typeId: number, authorId: number, date: number, notes?: string | null }
+    { typeId, authorId, date, notes }: { typeId: number, authorId: number, date: number, notes?: string }
   ): Promise<Training> {
     const trainingType = await this.getTrainingType(groupId, typeId)
     const training = await this.trainingRepository.save(this.trainingRepository.create({


### PR DESCRIPTION
I noticed these bugs when trying to fix the sometimes broken `/trainings schedule` command on `arora-discord`. The actual fix for this bug will be done on that repository as it passes `null` instead of `undefined` when no notes are specified.